### PR TITLE
Make ollama_client using Ollama OpenAI compatible API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0
 	github.com/llm-operator/model-manager v0.25.0
 	github.com/llm-operator/rbac-manager v0.18.0
-	github.com/ollama/ollama v0.1.32
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/ollama/ollama v0.1.32 h1:u3ojNk3nQDJo7mhJbD4WTEi0cqWTvXcr8IYgJLAkGaU=
-github.com/ollama/ollama v0.1.32/go.mod h1:aDL0iI5qcMYl12U5X0VhSQUVUYmnA5HIwYMrCIVWeYk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -57,7 +57,7 @@ func run(ctx context.Context, c *config.Config) error {
 	}()
 
 	go func() {
-		s := server.New()
+		s := server.New(c.OllamaServerAddr)
 		errCh <- s.Run(ctx, c.GRPCPort, c.AuthConfig)
 	}()
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -9,8 +9,10 @@ import (
 
 // Config is the configuration.
 type Config struct {
-	GRPCPort int `yaml:"grpcPort"`
-	HTTPPort int `yaml:"httpPort"`
+	GRPCPort         int    `yaml:"grpcPort"`
+	HTTPPort         int    `yaml:"httpPort"`
+	MonitoringPort   int    `yaml:"monitoringPort"`
+	OllamaServerAddr string `yaml:"ollamaServerAddr"`
 
 	AuthConfig AuthConfig `yaml:"auth"`
 }
@@ -39,6 +41,12 @@ func (c *Config) Validate() error {
 	}
 	if c.HTTPPort <= 0 {
 		return fmt.Errorf("httpPort must be greater than 0")
+	}
+	if c.MonitoringPort <= 0 {
+		return fmt.Errorf("monitoringPort must be greater than 0")
+	}
+	if c.OllamaServerAddr == "" {
+		return fmt.Errorf("ollamaServerAddr must be set")
 	}
 	if err := c.AuthConfig.Validate(); err != nil {
 		return err

--- a/server/internal/server/completions.go
+++ b/server/internal/server/completions.go
@@ -2,9 +2,13 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"net/http"
 
 	v1 "github.com/llm-operator/inference-manager/api/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // CreateChatCompletion creates a chat completion.
@@ -14,5 +18,30 @@ func (s *S) CreateChatCompletion(
 ) (*v1.ChatCompletion, error) {
 	log.Printf("Received a CreateChatCompletion request: %+v\n", req)
 
-	return handleChatRequest(ctx, req)
+	if req.Stream {
+		return nil, status.Error(codes.Unimplemented, "Streaming chat completions is not supported")
+	}
+
+	client := newClient(s.ollamaServerAddr)
+
+	bytes, err := client.sendRequest(ctx, http.MethodPost, "/v1/chat/completions", req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to create a chat completion: %s", err)
+	}
+
+	var resp v1.ChatCompletion
+	if err := json.Unmarshal(bytes, &resp); err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to unmarshal chat completion response: %s", err)
+	}
+
+	if err := processChatCompletionResponse(&resp); err != nil {
+		return nil, status.Errorf(codes.Internal, "Failed to process chat completion response: %s", err)
+	}
+	return &resp, nil
+}
+
+func processChatCompletionResponse(resp *v1.ChatCompletion) error {
+	// TODO(guangrui): process and publish metrics.
+	log.Printf("Received a chat completion: %+v\n", resp)
+	return nil
 }

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -14,15 +14,18 @@ import (
 )
 
 // New creates a server.
-func New() *S {
-	return &S{}
+func New(ollamaServerAddr string) *S {
+	return &S{
+		ollamaServerAddr: ollamaServerAddr,
+	}
 }
 
 // S is a server.
 type S struct {
 	v1.UnimplementedChatServiceServer
 
-	srv *grpc.Server
+	ollamaServerAddr string
+	srv              *grpc.Server
 }
 
 // Run starts the gRPC server.


### PR DESCRIPTION
Ollama go sdk does not support chat using OpenAI compatible API, which is recently introduced in Ollama. Copy related functions from Ollama SDK and alternate it to process interfence-manager-server messages