### PR TITLE
Make small changes to Helm charts

### DIFF
--- a/deployments/engine/templates/deployment.yaml
+++ b/deployments/engine/templates/deployment.yaml
@@ -31,10 +31,10 @@ spec:
         - name: ollama
           containerPort: {{ .Values.ollamaPort }}
           protocol: TCP
-        {{- if .Values.enableGpu }}
+        {{ if gt .Values.resources.gpu 0 }}
         resources:
           limits:
-            nvidia.com/gpu: {{ .Values.gpuNumber }}
+            nvidia.com/gpu: {{ .Values.resources.gpu }}
         {{- end }}
         {{- with .Values.global.awsSecret }}
         {{- if .name }}

--- a/deployments/engine/templates/scaledobject.yaml
+++ b/deployments/engine/templates/scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enableKeda }}
+{{- if .Values.autoscaling.enableKeda }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -12,14 +12,14 @@ spec:
     name: {{ include "inference-manager-engine.fullname" . }}
   pollingInterval: 15
   cooldownPeriod: 30
-  minReplicaCount:  {{ .Values.scaledobject.minReplicaCount }}
-  maxReplicaCount:  {{ .Values.scaledobject.maxReplicaCount }}
+  minReplicaCount:  {{ .Values.autoscaling.scaledobject.minReplicaCount }}
+  maxReplicaCount:  {{ .Values.autoscaling.scaledobject.maxReplicaCount }}
   # uncomment this if it is desired to scale to zero.
   # idleReplicaCount: 0
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: {{ .Values.scaledobject.prometheusServerAddr }}
+        serverAddress: {{ .Values.autoscaling.scaledobject.prometheusServerAddr }}
         metricName: gpu-util
         metricType: Value
         query: |-

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -26,16 +26,15 @@ image:
   repository: public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-engine
   pullPolicy: IfNotPresent
 
-ingress:
-  ingressClassName:
-
 version:
 
-enableGpu: true
-gpuNumber: 1
+resources:
+  gpu: 1
 
-enableKeda: true
-scaledobject:
-  minReplicaCount: 1
-  maxReplicaCount: 2
-  prometheusServerAddr: http://prometheus-server.monitoring.svc.cluster.local
+autoscaling:
+  # TODO(kenji): Enable once Keda installation is supported in the Terraform provisioning.
+  enableKeda: false
+  scaledobject:
+    minReplicaCount: 1
+    maxReplicaCount: 2
+    prometheusServerAddr:


### PR DESCRIPTION
- Do not set env var for NVIDIA drivers. This is done by the container runtime.
- Disable KEDA by default. We can enable once we update the overall installation flow.
- Make other minor tweaks