### PR TITLE
Add docker-compose.yaml

### DIFF
--- a/configs/server/config.yaml
+++ b/configs/server/config.yaml
@@ -1,0 +1,5 @@
+httpPort: 8080
+grpcPort: 8081
+monitoringPort: 8083
+
+ollamaServerAddr: engine:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,45 @@
+version: "3.8"
+
+services:
+
+  server:
+    hostname: server
+    build:
+      context: .
+      dockerfile: ./build/server/Dockerfile
+    command:
+    - run
+    - --config
+    - /etc/config/config.yaml
+    environment:
+      DB_PASSWORD: password
+    ports:
+    - 8080:8080
+    - 8081:8081
+    - 8083:8083
+    volumes:
+    - ./configs/server:/etc/config
+    restart: on-failure
+    networks:
+    - inference-manager
+
+  engine:
+    hostname: engine
+    build:
+      context: .
+      dockerfile: ./build/engine/Dockerfile
+    command:
+    - run
+    - --config
+    - /etc/config/config.yaml
+    ports:
+    - 18080:8080
+    - 18082:8082
+    volumes:
+    - ./configs/engine:/etc/config
+    restart: on-failure
+    networks:
+    - inference-manager
+
+networks:
+  inference-manager:


### PR DESCRIPTION
This is convenient to test inference-manager-{engine,server} locally without a kind cluster, which requires docker-image loading.