### PR TITLE
Remove redudant log message on informer

### DIFF
--- a/server/internal/k8s/informer.go
+++ b/server/internal/k8s/informer.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"log"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -50,10 +49,9 @@ func NewInformers(
 	}, nil
 }
 
-// Start starts the informers.
-func (is *Informers) Start() {
-	log.Printf("Starting informers\n")
-	go is.podInformer.Run(is.stopCh)
+// Run runs the informer.
+func (is *Informers) Run() {
+	is.podInformer.Run(is.stopCh)
 }
 
 // SetPodEventHandlers sets the specified handlers to the Pod informer.

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -72,8 +72,8 @@ func (r *R) Run(ctx context.Context, errCh chan error) error {
 		return err
 	}
 
-	is.Start()
-	log.Printf("Pod informer started.\n")
+	log.Printf("Starting informer.\n")
+	go is.Run()
 
 	// refresh routes periodically, since a engine may evict models.
 	ticker := time.NewTicker(tickPeriod)


### PR DESCRIPTION
We don't need to print before/after Start().

Also rename Start() to Run() and move the goroutine to the caller. This is a personal preference.