### PR TITLE
Remove the logic for removing "ft:" from model name

### DIFF
--- a/engine/internal/modelsyncer/syncer.go
+++ b/engine/internal/modelsyncer/syncer.go
@@ -175,11 +175,7 @@ func (s *S) registerModel(ctx context.Context, modelID string) error {
 		From:        baseModel,
 		AdapterPath: f.Name(),
 	}
-	modelName, err := ollamaModelName(modelID)
-	if err != nil {
-		return err
-	}
-	if err := s.om.CreateNewModel(modelName, ms); err != nil {
+	if err := s.om.CreateNewModel(modelID, ms); err != nil {
 		return fmt.Errorf("create new model: %s", err)
 	}
 	log.Printf("Registered the model successfully\n")
@@ -193,11 +189,4 @@ func extractBaseModel(modelID string) (string, error) {
 		return "", fmt.Errorf("invalid model ID: %q", modelID)
 	}
 	return strings.Join(l[1:len(l)-1], ":"), nil
-}
-
-func ollamaModelName(modelID string) (string, error) {
-	if !strings.HasPrefix(modelID, "ft:") {
-		return "", fmt.Errorf("invalid model ID: %q", modelID)
-	}
-	return modelID[3:], nil
 }

--- a/engine/internal/modelsyncer/syncer_test.go
+++ b/engine/internal/modelsyncer/syncer_test.go
@@ -45,7 +45,7 @@ func TestPullModel(t *testing.T) {
 				},
 			},
 			wantCreated: []string{
-				"google-gemma-2b:fine-tuning-wpsd9kb5nl",
+				"ft:google-gemma-2b:fine-tuning-wpsd9kb5nl",
 			},
 			wantRegisteredModels: []string{
 				"ft:google-gemma-2b:fine-tuning-wpsd9kb5nl",
@@ -92,34 +92,6 @@ func TestExtractBaseModel(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.modelID, func(t *testing.T) {
 			got, err := extractBaseModel(tc.modelID)
-			if tc.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
-func TestOllamaModelName(t *testing.T) {
-	tcs := []struct {
-		modelID string
-		want    string
-		wantErr bool
-	}{
-		{
-			modelID: "ft:gemma:2b-custom-model-name-7p4lURel",
-			want:    "gemma:2b-custom-model-name-7p4lURel",
-		},
-		{
-			modelID: "bogus",
-			wantErr: true,
-		},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.modelID, func(t *testing.T) {
-			got, err := ollamaModelName(tc.modelID)
 			if tc.wantErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
This was to be consistent with OpenAI, but it is making things complicated unnecessarily.