### PR TITLE
Remove "ft:" only from Ollama model names

### DIFF
--- a/common/pkg/models/ollama.go
+++ b/common/pkg/models/ollama.go
@@ -1,0 +1,13 @@
+package models
+
+import "strings"
+
+// OllamaModelName returns the Ollama model name from the model ID used in LLM Operator.
+//
+// Ollama does not accept more than two ":" while the model ID of the fine-tuning jobs is be "ft:<base-model>:<suffix>".
+func OllamaModelName(modelID string) string {
+	if !strings.HasPrefix(modelID, "ft:") {
+		return modelID
+	}
+	return modelID[3:]
+}

--- a/common/pkg/models/ollama_test.go
+++ b/common/pkg/models/ollama_test.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOllamaModelName(t *testing.T) {
+	tcs := []struct {
+		modelID string
+		want    string
+	}{
+		{
+			modelID: "ft:gemma:2b-custom-model-name-7p4lURel",
+			want:    "gemma:2b-custom-model-name-7p4lURel",
+		},
+		{
+			modelID: "google-gemma-2b",
+			want:    "google-gemma-2b",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.modelID, func(t *testing.T) {
+			got := OllamaModelName(tc.modelID)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/engine/internal/modelsyncer/syncer.go
+++ b/engine/internal/modelsyncer/syncer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/llm-operator/inference-manager/common/pkg/models"
 	"github.com/llm-operator/inference-manager/engine/internal/ollama"
 	mv1 "github.com/llm-operator/model-manager/api/v1"
 	"google.golang.org/grpc"
@@ -175,7 +176,7 @@ func (s *S) registerModel(ctx context.Context, modelID string) error {
 		From:        baseModel,
 		AdapterPath: f.Name(),
 	}
-	if err := s.om.CreateNewModel(modelID, ms); err != nil {
+	if err := s.om.CreateNewModel(models.OllamaModelName(modelID), ms); err != nil {
 		return fmt.Errorf("create new model: %s", err)
 	}
 	log.Printf("Registered the model successfully\n")

--- a/engine/internal/modelsyncer/syncer_test.go
+++ b/engine/internal/modelsyncer/syncer_test.go
@@ -45,7 +45,7 @@ func TestPullModel(t *testing.T) {
 				},
 			},
 			wantCreated: []string{
-				"ft:google-gemma-2b:fine-tuning-wpsd9kb5nl",
+				"google-gemma-2b:fine-tuning-wpsd9kb5nl",
 			},
 			wantRegisteredModels: []string{
 				"ft:google-gemma-2b:fine-tuning-wpsd9kb5nl",

--- a/server/internal/server/completions.go
+++ b/server/internal/server/completions.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	v1 "github.com/llm-operator/inference-manager/api/v1"
+	"github.com/llm-operator/inference-manager/common/pkg/models"
 	mv1 "github.com/llm-operator/model-manager/api/v1"
 	"github.com/llm-operator/rbac-manager/pkg/auth"
 	"google.golang.org/grpc/codes"
@@ -77,6 +78,14 @@ func (s *S) CreateChatCompletion(
 	}
 
 	log.Printf("Forwarding completion request to %s\n", dest)
+
+	// Convert to the Ollama model name and marshal the request.
+	createReq.Model = models.OllamaModelName(createReq.Model)
+	reqBody, err = json.Marshal(&createReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	// Forward the request to the Ollama server.
 	baseURL := &url.URL{


### PR DESCRIPTION
Ollama doesn't accept "ft:" prefix as a model name cannot contain more than ":".

Drop the "ft:" prefix and have the same logic in the inference-manager-server.