### PR TITLE
engine: Make ListModels return model names without Ollama conversion

### DIFF
--- a/engine/internal/ollama/manager.go
+++ b/engine/internal/ollama/manager.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/llm-operator/inference-manager/api/v1"
 	"github.com/ollama/ollama/api"
 )
 
@@ -170,19 +169,4 @@ func (m *Manager) DeleteModel(ctx context.Context, modelName string) error {
 	return m.client.Delete(ctx, &api.DeleteRequest{
 		Model: modelName,
 	})
-}
-
-// ListModels lists the loaded models.
-func (m *Manager) ListModels(ctx context.Context) ([]*v1.Model, error) {
-	var models []*v1.Model
-	resp, err := m.client.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, model := range resp.Models {
-		models = append(models, &v1.Model{
-			Id: model.Name,
-		})
-	}
-	return models, nil
 }

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -87,11 +87,14 @@ func (s *S) DeleteModel(ctx context.Context, req *v1.DeleteModelRequest) (*empty
 
 // ListModels lists all downloaded models in the engine.
 func (s *S) ListModels(ctx context.Context, req *v1.ListModelsRequest) (*v1.ListModelsResponse, error) {
-	ms, err := s.om.ListModels(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Failed to list models: %s", err)
+	ids := s.syncer.ListSyncedModelIDs(ctx)
+	var models []*v1.Model
+	for _, id := range ids {
+		models = append(models, &v1.Model{
+			Id: id,
+		})
 	}
 	return &v1.ListModelsResponse{
-		Models: ms,
+		Models: models,
 	}, nil
 }


### PR DESCRIPTION
Query model names from Syncer instead of Ollama as Ollama can return a different model name (e.g., ":latest" suffix, "ft:" prefix).