### PR TITLE
Do not initialize Ollama client from env var

### DIFF
--- a/engine/cmd/run.go
+++ b/engine/cmd/run.go
@@ -48,14 +48,11 @@ var runCmd = &cobra.Command{
 }
 
 func run(ctx context.Context, c *config.Config) error {
-	if err := os.Setenv("OLLAMA_HOST", fmt.Sprintf("0.0.0.0:%d", c.OllamaPort)); err != nil {
+	addr := fmt.Sprintf("0.0.0.0:%d", c.OllamaPort)
+	if err := os.Setenv("OLLAMA_HOST", addr); err != nil {
 		return err
 	}
-
-	om, err := ollama.NewManager()
-	if err != nil {
-		return err
-	}
+	om := ollama.NewManager(addr)
 
 	errCh := make(chan error)
 

--- a/engine/internal/ollama/manager.go
+++ b/engine/internal/ollama/manager.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,14 +16,14 @@ import (
 )
 
 // NewManager returns a new Manager.
-func NewManager() (*Manager, error) {
-	client, err := api.ClientFromEnvironment()
-	if err != nil {
-		return nil, err
+func NewManager(addr string) *Manager {
+	url := &url.URL{
+		Scheme: "http",
+		Host:   addr,
 	}
 	return &Manager{
-		client: client,
-	}, nil
+		client: api.NewClient(url, http.DefaultClient),
+	}
 }
 
 // Manager manages the Ollama service.


### PR DESCRIPTION
Ollama processes env vars from init(), and setting the env var later in the code doesn't work.

https://github.com/ollama/ollama/blob/main/envconfig/config.go#L130