### PR TITLE
Make engine register via gRPC call

### DIFF
--- a/api/v1/inference_server_worker.pb.go
+++ b/api/v1/inference_server_worker.pb.go
@@ -10,6 +10,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -19,6 +20,166 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type EngineStatus struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EngineId string   `protobuf:"bytes,1,opt,name=engine_id,json=engineId,proto3" json:"engine_id,omitempty"`
+	ModelIds []string `protobuf:"bytes,2,rep,name=model_ids,json=modelIds,proto3" json:"model_ids,omitempty"`
+}
+
+func (x *EngineStatus) Reset() {
+	*x = EngineStatus{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_api_v1_inference_server_worker_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *EngineStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EngineStatus) ProtoMessage() {}
+
+func (x *EngineStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_inference_server_worker_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EngineStatus.ProtoReflect.Descriptor instead.
+func (*EngineStatus) Descriptor() ([]byte, []int) {
+	return file_api_v1_inference_server_worker_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *EngineStatus) GetEngineId() string {
+	if x != nil {
+		return x.EngineId
+	}
+	return ""
+}
+
+func (x *EngineStatus) GetModelIds() []string {
+	if x != nil {
+		return x.ModelIds
+	}
+	return nil
+}
+
+type ProcessTasksRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Types that are assignable to Message:
+	//
+	//	*ProcessTasksRequest_EngineStatus
+	Message isProcessTasksRequest_Message `protobuf_oneof:"message"`
+}
+
+func (x *ProcessTasksRequest) Reset() {
+	*x = ProcessTasksRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_api_v1_inference_server_worker_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ProcessTasksRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcessTasksRequest) ProtoMessage() {}
+
+func (x *ProcessTasksRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_inference_server_worker_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcessTasksRequest.ProtoReflect.Descriptor instead.
+func (*ProcessTasksRequest) Descriptor() ([]byte, []int) {
+	return file_api_v1_inference_server_worker_proto_rawDescGZIP(), []int{1}
+}
+
+func (m *ProcessTasksRequest) GetMessage() isProcessTasksRequest_Message {
+	if m != nil {
+		return m.Message
+	}
+	return nil
+}
+
+func (x *ProcessTasksRequest) GetEngineStatus() *EngineStatus {
+	if x, ok := x.GetMessage().(*ProcessTasksRequest_EngineStatus); ok {
+		return x.EngineStatus
+	}
+	return nil
+}
+
+type isProcessTasksRequest_Message interface {
+	isProcessTasksRequest_Message()
+}
+
+type ProcessTasksRequest_EngineStatus struct {
+	EngineStatus *EngineStatus `protobuf:"bytes,1,opt,name=engine_status,json=engineStatus,proto3,oneof"` // TODO(kenji): Add task result.
+}
+
+func (*ProcessTasksRequest_EngineStatus) isProcessTasksRequest_Message() {}
+
+type ProcessTasksResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *ProcessTasksResponse) Reset() {
+	*x = ProcessTasksResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_api_v1_inference_server_worker_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ProcessTasksResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcessTasksResponse) ProtoMessage() {}
+
+func (x *ProcessTasksResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_inference_server_worker_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcessTasksResponse.ProtoReflect.Descriptor instead.
+func (*ProcessTasksResponse) Descriptor() ([]byte, []int) {
+	return file_api_v1_inference_server_worker_proto_rawDescGZIP(), []int{2}
+}
+
 var File_api_v1_inference_server_worker_proto protoreflect.FileDescriptor
 
 var file_api_v1_inference_server_worker_proto_rawDesc = []byte{
@@ -26,21 +187,65 @@ var file_api_v1_inference_server_worker_proto_rawDesc = []byte{
 	0x63, 0x65, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x5f, 0x77, 0x6f, 0x72, 0x6b, 0x65, 0x72,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x12, 0x1f, 0x6c, 0x6c, 0x6d, 0x6f, 0x70, 0x65, 0x72, 0x61,
 	0x74, 0x6f, 0x72, 0x2e, 0x69, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x2e, 0x73, 0x65,
-	0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x32, 0x18, 0x0a, 0x16, 0x49, 0x6e, 0x66, 0x65, 0x72,
-	0x65, 0x6e, 0x63, 0x65, 0x57, 0x6f, 0x72, 0x6b, 0x65, 0x72, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63,
-	0x65, 0x42, 0x32, 0x5a, 0x30, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f,
-	0x6c, 0x6c, 0x6d, 0x2d, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x2f, 0x69, 0x6e, 0x66,
-	0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x2d, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x2f, 0x61,
-	0x70, 0x69, 0x2f, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x1a, 0x1d, 0x61, 0x70, 0x69, 0x2f, 0x76, 0x31, 0x2f,
+	0x69, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x5f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x48, 0x0a, 0x0c, 0x45, 0x6e, 0x67, 0x69, 0x6e, 0x65,
+	0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12, 0x1b, 0x0a, 0x09, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65,
+	0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x65, 0x6e, 0x67, 0x69, 0x6e,
+	0x65, 0x49, 0x64, 0x12, 0x1b, 0x0a, 0x09, 0x6d, 0x6f, 0x64, 0x65, 0x6c, 0x5f, 0x69, 0x64, 0x73,
+	0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x08, 0x6d, 0x6f, 0x64, 0x65, 0x6c, 0x49, 0x64, 0x73,
+	0x22, 0x76, 0x0a, 0x13, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x54, 0x61, 0x73, 0x6b, 0x73,
+	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x54, 0x0a, 0x0d, 0x65, 0x6e, 0x67, 0x69, 0x6e,
+	0x65, 0x5f, 0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2d,
+	0x2e, 0x6c, 0x6c, 0x6d, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x2e, 0x69, 0x6e, 0x66,
+	0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31,
+	0x2e, 0x45, 0x6e, 0x67, 0x69, 0x6e, 0x65, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x48, 0x00, 0x52,
+	0x0c, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x42, 0x09, 0x0a,
+	0x07, 0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x22, 0x16, 0x0a, 0x14, 0x50, 0x72, 0x6f, 0x63,
+	0x65, 0x73, 0x73, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x32, 0x9c, 0x01, 0x0a, 0x16, 0x49, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x57, 0x6f,
+	0x72, 0x6b, 0x65, 0x72, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x81, 0x01, 0x0a, 0x0c,
+	0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x12, 0x34, 0x2e, 0x6c,
+	0x6c, 0x6d, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x2e, 0x69, 0x6e, 0x66, 0x65, 0x72,
+	0x65, 0x6e, 0x63, 0x65, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50,
+	0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x54, 0x61, 0x73, 0x6b, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x1a, 0x35, 0x2e, 0x6c, 0x6c, 0x6d, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72,
+	0x2e, 0x69, 0x6e, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x65,
+	0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x54, 0x61, 0x73, 0x6b,
+	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x28, 0x01, 0x30, 0x01, 0x42,
+	0x32, 0x5a, 0x30, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6c, 0x6c,
+	0x6d, 0x2d, 0x6f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x2f, 0x69, 0x6e, 0x66, 0x65, 0x72,
+	0x65, 0x6e, 0x63, 0x65, 0x2d, 0x6d, 0x61, 0x6e, 0x61, 0x67, 0x65, 0x72, 0x2f, 0x61, 0x70, 0x69,
+	0x2f, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
-var file_api_v1_inference_server_worker_proto_goTypes = []interface{}{}
+var (
+	file_api_v1_inference_server_worker_proto_rawDescOnce sync.Once
+	file_api_v1_inference_server_worker_proto_rawDescData = file_api_v1_inference_server_worker_proto_rawDesc
+)
+
+func file_api_v1_inference_server_worker_proto_rawDescGZIP() []byte {
+	file_api_v1_inference_server_worker_proto_rawDescOnce.Do(func() {
+		file_api_v1_inference_server_worker_proto_rawDescData = protoimpl.X.CompressGZIP(file_api_v1_inference_server_worker_proto_rawDescData)
+	})
+	return file_api_v1_inference_server_worker_proto_rawDescData
+}
+
+var file_api_v1_inference_server_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_api_v1_inference_server_worker_proto_goTypes = []interface{}{
+	(*EngineStatus)(nil),         // 0: llmoperator.inference.server.v1.EngineStatus
+	(*ProcessTasksRequest)(nil),  // 1: llmoperator.inference.server.v1.ProcessTasksRequest
+	(*ProcessTasksResponse)(nil), // 2: llmoperator.inference.server.v1.ProcessTasksResponse
+}
 var file_api_v1_inference_server_worker_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: llmoperator.inference.server.v1.ProcessTasksRequest.engine_status:type_name -> llmoperator.inference.server.v1.EngineStatus
+	1, // 1: llmoperator.inference.server.v1.InferenceWorkerService.ProcessTasks:input_type -> llmoperator.inference.server.v1.ProcessTasksRequest
+	2, // 2: llmoperator.inference.server.v1.InferenceWorkerService.ProcessTasks:output_type -> llmoperator.inference.server.v1.ProcessTasksResponse
+	2, // [2:3] is the sub-list for method output_type
+	1, // [1:2] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_inference_server_worker_proto_init() }
@@ -48,18 +253,61 @@ func file_api_v1_inference_server_worker_proto_init() {
 	if File_api_v1_inference_server_worker_proto != nil {
 		return
 	}
+	file_api_v1_inference_server_proto_init()
+	if !protoimpl.UnsafeEnabled {
+		file_api_v1_inference_server_worker_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*EngineStatus); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_api_v1_inference_server_worker_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ProcessTasksRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_api_v1_inference_server_worker_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ProcessTasksResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+	}
+	file_api_v1_inference_server_worker_proto_msgTypes[1].OneofWrappers = []interface{}{
+		(*ProcessTasksRequest_EngineStatus)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_api_v1_inference_server_worker_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   0,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_api_v1_inference_server_worker_proto_goTypes,
 		DependencyIndexes: file_api_v1_inference_server_worker_proto_depIdxs,
+		MessageInfos:      file_api_v1_inference_server_worker_proto_msgTypes,
 	}.Build()
 	File_api_v1_inference_server_worker_proto = out.File
 	file_api_v1_inference_server_worker_proto_rawDesc = nil

--- a/api/v1/inference_server_worker.proto
+++ b/api/v1/inference_server_worker.proto
@@ -2,8 +2,25 @@ syntax = "proto3";
 
 package llmoperator.inference.server.v1;
 
+import "api/v1/inference_server.proto";
+
 option go_package = "github.com/llm-operator/inference-manager/api/v1";
 
+message EngineStatus {
+  string engine_id = 1;
+  repeated string model_ids = 2;
+}
+
+message ProcessTasksRequest {
+  oneof message {
+    EngineStatus engine_status = 1;
+    // TODO(kenji): Add task result.
+  }
+}
+
+message ProcessTasksResponse {
+}
+
 service InferenceWorkerService {
-  // TODO(kenji): Define RPC methods.
+  rpc ProcessTasks(stream ProcessTasksRequest) returns (stream ProcessTasksResponse) {}
 }

--- a/api/v1/inference_server_worker.swagger.json
+++ b/api/v1/inference_server_worker.swagger.json
@@ -4,6 +4,11 @@
     "title": "api/v1/inference_server_worker.proto",
     "version": "version not set"
   },
+  "tags": [
+    {
+      "name": "InferenceWorkerService"
+    }
+  ],
   "consumes": [
     "application/json"
   ],
@@ -38,6 +43,23 @@
           }
         }
       }
+    },
+    "v1EngineStatus": {
+      "type": "object",
+      "properties": {
+        "engineId": {
+          "type": "string"
+        },
+        "modelIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1ProcessTasksResponse": {
+      "type": "object"
     }
   }
 }

--- a/api/v1/inference_server_worker_grpc.pb.go
+++ b/api/v1/inference_server_worker_grpc.pb.go
@@ -3,7 +3,10 @@
 package v1
 
 import (
+	context "context"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // This is a compile-time assertion to ensure that this generated file
@@ -15,6 +18,7 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type InferenceWorkerServiceClient interface {
+	ProcessTasks(ctx context.Context, opts ...grpc.CallOption) (InferenceWorkerService_ProcessTasksClient, error)
 }
 
 type inferenceWorkerServiceClient struct {
@@ -25,10 +29,42 @@ func NewInferenceWorkerServiceClient(cc grpc.ClientConnInterface) InferenceWorke
 	return &inferenceWorkerServiceClient{cc}
 }
 
+func (c *inferenceWorkerServiceClient) ProcessTasks(ctx context.Context, opts ...grpc.CallOption) (InferenceWorkerService_ProcessTasksClient, error) {
+	stream, err := c.cc.NewStream(ctx, &InferenceWorkerService_ServiceDesc.Streams[0], "/llmoperator.inference.server.v1.InferenceWorkerService/ProcessTasks", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &inferenceWorkerServiceProcessTasksClient{stream}
+	return x, nil
+}
+
+type InferenceWorkerService_ProcessTasksClient interface {
+	Send(*ProcessTasksRequest) error
+	Recv() (*ProcessTasksResponse, error)
+	grpc.ClientStream
+}
+
+type inferenceWorkerServiceProcessTasksClient struct {
+	grpc.ClientStream
+}
+
+func (x *inferenceWorkerServiceProcessTasksClient) Send(m *ProcessTasksRequest) error {
+	return x.ClientStream.SendMsg(m)
+}
+
+func (x *inferenceWorkerServiceProcessTasksClient) Recv() (*ProcessTasksResponse, error) {
+	m := new(ProcessTasksResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // InferenceWorkerServiceServer is the server API for InferenceWorkerService service.
 // All implementations must embed UnimplementedInferenceWorkerServiceServer
 // for forward compatibility
 type InferenceWorkerServiceServer interface {
+	ProcessTasks(InferenceWorkerService_ProcessTasksServer) error
 	mustEmbedUnimplementedInferenceWorkerServiceServer()
 }
 
@@ -36,6 +72,9 @@ type InferenceWorkerServiceServer interface {
 type UnimplementedInferenceWorkerServiceServer struct {
 }
 
+func (UnimplementedInferenceWorkerServiceServer) ProcessTasks(InferenceWorkerService_ProcessTasksServer) error {
+	return status.Errorf(codes.Unimplemented, "method ProcessTasks not implemented")
+}
 func (UnimplementedInferenceWorkerServiceServer) mustEmbedUnimplementedInferenceWorkerServiceServer() {
 }
 
@@ -50,6 +89,32 @@ func RegisterInferenceWorkerServiceServer(s grpc.ServiceRegistrar, srv Inference
 	s.RegisterService(&InferenceWorkerService_ServiceDesc, srv)
 }
 
+func _InferenceWorkerService_ProcessTasks_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(InferenceWorkerServiceServer).ProcessTasks(&inferenceWorkerServiceProcessTasksServer{stream})
+}
+
+type InferenceWorkerService_ProcessTasksServer interface {
+	Send(*ProcessTasksResponse) error
+	Recv() (*ProcessTasksRequest, error)
+	grpc.ServerStream
+}
+
+type inferenceWorkerServiceProcessTasksServer struct {
+	grpc.ServerStream
+}
+
+func (x *inferenceWorkerServiceProcessTasksServer) Send(m *ProcessTasksResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+func (x *inferenceWorkerServiceProcessTasksServer) Recv() (*ProcessTasksRequest, error) {
+	m := new(ProcessTasksRequest)
+	if err := x.ServerStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // InferenceWorkerService_ServiceDesc is the grpc.ServiceDesc for InferenceWorkerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -57,6 +122,13 @@ var InferenceWorkerService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "llmoperator.inference.server.v1.InferenceWorkerService",
 	HandlerType: (*InferenceWorkerServiceServer)(nil),
 	Methods:     []grpc.MethodDesc{},
-	Streams:     []grpc.StreamDesc{},
-	Metadata:    "api/v1/inference_server_worker.proto",
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "ProcessTasks",
+			Handler:       _InferenceWorkerService_ProcessTasks_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+	},
+	Metadata: "api/v1/inference_server_worker.proto",
 }

--- a/engine/internal/processor/processor.go
+++ b/engine/internal/processor/processor.go
@@ -1,0 +1,79 @@
+package processor
+
+import (
+	"context"
+	"io"
+	"log"
+
+	v1 "github.com/llm-operator/inference-manager/api/v1"
+	"github.com/llm-operator/rbac-manager/pkg/auth"
+)
+
+type modelLister interface {
+	ListSyncedModelIDs(ctx context.Context) []string
+}
+
+// NewP returns a new processor.
+func NewP(
+	engineID string,
+	client v1.InferenceWorkerServiceClient,
+	modelLister modelLister,
+) *P {
+	return &P{
+		engineID:    engineID,
+		client:      client,
+		modelLister: modelLister,
+	}
+}
+
+// P processes tasks.
+type P struct {
+	engineID    string
+	client      v1.InferenceWorkerServiceClient
+	modelLister modelLister
+}
+
+// Run runs the processor.
+func (p *P) Run(ctx context.Context) error {
+	auth.AppendWorkerAuthorization(ctx)
+	stream, err := p.client.ProcessTasks(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Send an initial request for registraion.
+	log.Printf("Registering engine: %s\n", p.engineID)
+	if err := p.sendEngineStatus(ctx, stream); err != nil {
+		return err
+	}
+
+	// TODO(kenji): Periodically send engine status.
+
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// TODO(kenji): Process task.
+	}
+
+}
+
+func (p *P) sendEngineStatus(ctx context.Context, stream v1.InferenceWorkerService_ProcessTasksClient) error {
+	req := &v1.ProcessTasksRequest{
+		Message: &v1.ProcessTasksRequest_EngineStatus{
+			EngineStatus: &v1.EngineStatus{
+				EngineId: p.engineID,
+				ModelIds: p.modelLister.ListSyncedModelIDs(ctx),
+			},
+		},
+	}
+	if err := stream.Send(req); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Engine makes a bi-directional gRPC call to server and register itself.

Later we will add a logic to fetch inference tasks via the same streaming RPC call.