### PR TITLE
Define pipeReadWriteCloser

### DIFF
--- a/server/internal/infprocessor/pipe.go
+++ b/server/internal/infprocessor/pipe.go
@@ -1,0 +1,27 @@
+package infprocessor
+
+import "io"
+
+func newPipeReadWriteCloser() pipeReadWriteCloser {
+	pr, pw := io.Pipe()
+	return pipeReadWriteCloser{
+		PipeReader: pr,
+		PipeWriter: pw,
+	}
+}
+
+type pipeReadWriteCloser struct {
+	*io.PipeReader
+	*io.PipeWriter
+}
+
+// Close closes the pipe.
+func (c pipeReadWriteCloser) Close() error {
+	if err := c.PipeReader.Close(); err != nil {
+		return err
+	}
+	if err := c.PipeWriter.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/internal/infprocessor/pipe_test.go
+++ b/server/internal/infprocessor/pipe_test.go
@@ -1,0 +1,24 @@
+package infprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPipeReadWriteCloser(t *testing.T) {
+	p := newPipeReadWriteCloser()
+	go func() {
+		_, err := p.Write([]byte("hello"))
+		assert.NoError(t, err)
+	}()
+
+	buf := make([]byte, 5)
+	n, err := p.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", string(buf))
+
+	err = p.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This is used to write a server-sent-event that is sent from an engine to a task.RespCh.