### PR TITLE
Add the multi-cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ docker-compose build
 docker-compose up
 ```
 
+You can hit `inference-manager-server` at port 8080.
+
+```bash
+curl --request POST http://localhost:8080/v1/chat/completions -d '{
+  "model": "google-gemma-2b-it-q4",
+  "messages": [{"role": "user", "content": "hello"}]
+}'
+```
+
 ## Running Engine Locally
 
 Run the following command:

--- a/engine/cmd/run.go
+++ b/engine/cmd/run.go
@@ -51,11 +51,11 @@ var runCmd = &cobra.Command{
 }
 
 func run(ctx context.Context, c *config.Config) error {
-	addr := fmt.Sprintf("0.0.0.0:%d", c.OllamaPort)
-	if err := os.Setenv("OLLAMA_HOST", addr); err != nil {
+	ollamaAddr := fmt.Sprintf("0.0.0.0:%d", c.OllamaPort)
+	if err := os.Setenv("OLLAMA_HOST", ollamaAddr); err != nil {
 		return err
 	}
-	om := ollama.NewManager(addr)
+	om := ollama.NewManager(ollamaAddr)
 
 	errCh := make(chan error)
 
@@ -108,7 +108,12 @@ func run(ctx context.Context, c *config.Config) error {
 	if err != nil {
 		return err
 	}
-	p := processor.NewP(engineID, v1.NewInferenceWorkerServiceClient(conn), syncer)
+	p := processor.NewP(
+		engineID,
+		v1.NewInferenceWorkerServiceClient(conn),
+		ollamaAddr,
+		syncer,
+	)
 
 	go func() {
 		errCh <- p.Run(ctx)

--- a/engine/internal/processor/processor.go
+++ b/engine/internal/processor/processor.go
@@ -1,12 +1,22 @@
 package processor
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log"
+	"net/http"
+	"net/url"
 
 	v1 "github.com/llm-operator/inference-manager/api/v1"
+	"github.com/llm-operator/inference-manager/common/pkg/models"
+	"github.com/llm-operator/inference-manager/common/pkg/sse"
 	"github.com/llm-operator/rbac-manager/pkg/auth"
+)
+
+const (
+	completionPath = "/v1/chat/completions"
 )
 
 type modelLister interface {
@@ -17,11 +27,13 @@ type modelLister interface {
 func NewP(
 	engineID string,
 	client v1.InferenceWorkerServiceClient,
+	ollamaAddr string,
 	modelLister modelLister,
 ) *P {
 	return &P{
 		engineID:    engineID,
 		client:      client,
+		ollamaAddr:  ollamaAddr,
 		modelLister: modelLister,
 	}
 }
@@ -30,6 +42,7 @@ func NewP(
 type P struct {
 	engineID    string
 	client      v1.InferenceWorkerServiceClient
+	ollamaAddr  string
 	modelLister modelLister
 }
 
@@ -41,7 +54,6 @@ func (p *P) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Send an initial request for registraion.
 	log.Printf("Registering engine: %s\n", p.engineID)
 	if err := p.sendEngineStatus(ctx, stream); err != nil {
 		return err
@@ -50,19 +62,136 @@ func (p *P) Run(ctx context.Context) error {
 	// TODO(kenji): Periodically send engine status.
 
 	for {
-		_, err := stream.Recv()
+		resp, err := stream.Recv()
 		if err == io.EOF {
 			return nil
 		}
 		if err != nil {
 			return err
 		}
-		// TODO(kenji): Process task.
+		if err := p.processTask(ctx, stream, resp.NewTask); err != nil {
+			return err
+		}
 	}
-
 }
 
-func (p *P) sendEngineStatus(ctx context.Context, stream v1.InferenceWorkerService_ProcessTasksClient) error {
+type sender interface {
+	Send(*v1.ProcessTasksRequest) error
+}
+
+func (p *P) processTask(
+	ctx context.Context,
+	stream sender,
+	t *v1.Task,
+) error {
+	log.Printf("Processing task: %s\n", t.Id)
+
+	req, err := p.buildRequest(ctx, t)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// TODO(kenji): Send the error back to the server?
+		return err
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		httpResp := &v1.HttpResponse{
+			StatusCode: int32(resp.StatusCode),
+			Status:     resp.Status,
+		}
+		if err := p.sendHTTPResponse(ctx, stream, t, httpResp); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	respHeader := map[string]*v1.HeaderValue{}
+	for k, vs := range resp.Header {
+		respHeader[k] = &v1.HeaderValue{Values: vs}
+	}
+
+	var body []byte
+	if !t.Request.Stream {
+		// Non streaming response. Just copy the response body.
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+	}
+
+	httpResp := &v1.HttpResponse{
+		StatusCode: int32(resp.StatusCode),
+		Status:     resp.Status,
+		Header:     respHeader,
+		Body:       body,
+	}
+	if err := p.sendHTTPResponse(ctx, stream, t, httpResp); err != nil {
+		return err
+	}
+
+	if !t.Request.Stream {
+		return nil
+	}
+
+	scanner := sse.NewScanner(resp.Body)
+	for scanner.Scan() {
+		b := scanner.Text()
+		e := &v1.ServerSentEvent{
+			Data: []byte(b + sse.DoubleNewline),
+		}
+		if err := p.sendServerSentEvent(ctx, stream, t, e); err != nil {
+			return err
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		// TODO(kenji): Send the error back to the server?
+		return err
+	}
+
+	e := &v1.ServerSentEvent{
+		IsLastEvent: true,
+	}
+	if err := p.sendServerSentEvent(ctx, stream, t, e); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *P) buildRequest(ctx context.Context, t *v1.Task) (*http.Request, error) {
+	t.Request.Model = models.OllamaModelName(t.Request.Model)
+	reqBody, err := json.Marshal(t.Request)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL := &url.URL{
+		Scheme: "http",
+		Host:   p.ollamaAddr,
+	}
+	requestURL := baseURL.JoinPath(completionPath).String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	// Copy headers.
+	for k, vs := range t.Header {
+		for _, v := range vs.Values {
+			req.Header.Add(k, v)
+		}
+	}
+	return req, nil
+}
+
+func (p *P) sendEngineStatus(ctx context.Context, stream sender) error {
 	req := &v1.ProcessTasksRequest{
 		Message: &v1.ProcessTasksRequest_EngineStatus{
 			EngineStatus: &v1.EngineStatus{
@@ -75,5 +204,57 @@ func (p *P) sendEngineStatus(ctx context.Context, stream v1.InferenceWorkerServi
 		return err
 	}
 
+	return nil
+}
+
+func (p *P) sendHTTPResponse(
+	ctx context.Context,
+	stream sender,
+	t *v1.Task,
+	resp *v1.HttpResponse,
+) error {
+	result := &v1.TaskResult{
+		TaskId: t.Id,
+		Message: &v1.TaskResult_HttpResponse{
+			HttpResponse: resp,
+		},
+	}
+	if err := p.sendTaskResult(ctx, stream, result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *P) sendServerSentEvent(
+	ctx context.Context,
+	stream sender,
+	t *v1.Task,
+	e *v1.ServerSentEvent,
+) error {
+	result := &v1.TaskResult{
+		TaskId: t.Id,
+		Message: &v1.TaskResult_ServerSentEvent{
+			ServerSentEvent: e,
+		},
+	}
+	if err := p.sendTaskResult(ctx, stream, result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *P) sendTaskResult(
+	ctx context.Context,
+	stream sender,
+	result *v1.TaskResult,
+) error {
+	req := &v1.ProcessTasksRequest{
+		Message: &v1.ProcessTasksRequest_TaskResult{
+			TaskResult: result,
+		},
+	}
+	if err := stream.Send(req); err != nil {
+		return err
+	}
 	return nil
 }

--- a/engine/internal/processor/processor_test.go
+++ b/engine/internal/processor/processor_test.go
@@ -1,0 +1,122 @@
+package processor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	v1 "github.com/llm-operator/inference-manager/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestP(t *testing.T) {
+	// Start a fake ollama server.
+	ollamaSrv, err := newFakeOllamaServer()
+	assert.NoError(t, err)
+
+	go ollamaSrv.serve()
+	defer ollamaSrv.shutdown(context.Background())
+
+	assert.Eventuallyf(t, ollamaSrv.isReady, 10*time.Second, 100*time.Millisecond, "engine server is not ready")
+
+	processor := NewP(
+		"engine_id0",
+		nil,
+		fmt.Sprintf("localhost:%d", ollamaSrv.port()),
+		&fakeModelLister{},
+	)
+
+	fakeClient := &fakeProcessTasksClient{}
+
+	task := &v1.Task{
+		Request: &v1.CreateChatCompletionRequest{
+			Model: "m0",
+		},
+	}
+
+	err = processor.processTask(context.Background(), fakeClient, task)
+	assert.NoError(t, err)
+	resp := fakeClient.gotReq.GetTaskResult().GetHttpResponse()
+	assert.Equal(t, http.StatusOK, int(resp.StatusCode))
+	assert.Equal(t, "ok", string(resp.Body))
+}
+
+func newFakeOllamaServer() (*fakeOllamaServer, error) {
+	m := http.NewServeMux()
+	m.Handle(completionPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("ok"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}))
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return nil, err
+	}
+
+	return &fakeOllamaServer{
+		srv: &http.Server{
+			Handler: m,
+		},
+		listener: listener,
+	}, nil
+}
+
+type fakeOllamaServer struct {
+	srv      *http.Server
+	listener net.Listener
+}
+
+func (s *fakeOllamaServer) serve() {
+	_ = s.srv.Serve(s.listener)
+}
+
+func (s *fakeOllamaServer) shutdown(ctx context.Context) {
+	_ = s.srv.Shutdown(ctx)
+}
+
+func (s *fakeOllamaServer) isReady() bool {
+	baseURL := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("localhost:%d", s.port()),
+	}
+	requestURL := baseURL.JoinPath(completionPath).String()
+	freq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, requestURL, bytes.NewReader(nil))
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(freq)
+	if err != nil {
+		return false
+	}
+
+	return resp.StatusCode == http.StatusOK
+}
+
+func (s *fakeOllamaServer) port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+type fakeModelLister struct {
+}
+
+func (f *fakeModelLister) ListSyncedModelIDs(ctx context.Context) []string {
+	return nil
+}
+
+type fakeProcessTasksClient struct {
+	gotReq *v1.ProcessTasksRequest
+}
+
+func (c *fakeProcessTasksClient) Send(req *v1.ProcessTasksRequest) error {
+	c.gotReq = req
+	return nil
+}

--- a/server/internal/infprocessor/pipe.go
+++ b/server/internal/infprocessor/pipe.go
@@ -25,3 +25,11 @@ func (c pipeReadWriteCloser) Close() error {
 	}
 	return nil
 }
+
+// closeWrite closes the write pipe.
+func (c pipeReadWriteCloser) closeWrite() error {
+	if err := c.PipeWriter.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/internal/server/ws_server.go
+++ b/server/internal/server/ws_server.go
@@ -98,10 +98,13 @@ func (ws *WS) processMessagesFromEngine(srv v1.InferenceWorkerService_ProcessTas
 
 	switch msg := req.Message.(type) {
 	case *v1.ProcessTasksRequest_EngineStatus:
-		log.Printf("Engine status: %v\n", msg.EngineStatus)
 		ws.infProcessor.AddOrUpdateEngineStatus(srv, msg.EngineStatus)
+	case *v1.ProcessTasksRequest_TaskResult:
+		if err := ws.infProcessor.ProcessTaskResult(msg.TaskResult); err != nil {
+			return err
+		}
 	default:
-		log.Printf("Unknown message type: %T\n", msg)
+		return fmt.Errorf("unknown message type: %T", msg)
 	}
 
 	return nil


### PR DESCRIPTION
 With this change, a inference request is processed with the following flow:

1. Server receives a request.
2. Server forwards the request to the engine.
3. Engine processes the request by talking to Ollama.
4. Engine sends the response back to the server.
5. Server forwards the response back to the client.

The engine and the server communicates with bi-directional gRPC.
