### PR TITLE
Be able to configure the type of worker grpc service

### DIFF
--- a/deployments/server/templates/service.yaml
+++ b/deployments/server/templates/service.yaml
@@ -30,12 +30,16 @@ metadata:
     {{- include "inference-manager-server.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.global.workerServiceGrpcService.annotations | nindent 4 }}
+    {{- toYaml .Values.workerServiceGrpcService.annotations | nindent 4 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.workerServiceGrpcService.type }}
   ports:
   - name: ws-grpc
-    port: {{ .Values.workerServiceGrpcPort }}
+    port: {{ .Values.workerServiceGrpcService.port }}
     protocol: TCP
     targetPort: ws-grpc
+    {{- if .Values.workerServiceGrpcService.nodePort }}
+    nodePort: {{ .Values.workerServiceGrpcService.nodePort }}
+    {{- end }}
   selector:
     {{- include "inference-manager-server.selectorLabels" . | nindent 4 }}

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -26,6 +26,12 @@ grpcPort: 8081
 workerServiceGrpcPort: 8082
 monitoringPort: 8083
 
+workerServiceGrpcService:
+  type: ClusterIP
+  port: 8082
+  nodePort:
+  annotations:
+
 workerServiceTls:
   enable: false
   secretName:


### PR DESCRIPTION
This can be set to Loadbalancer or NodePort when the service is externally reachable.