### PR TITLE
Increase Ollama keep alive to keep models in GPU memory for a longer period

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "inference-manager-engine.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    ollamaPort: {{ .Values.ollamaPort }}
+    ollama:
+      port: {{ .Values.ollama.port }}
+      keepAlive: {{ .Values.ollama.keepAlive }}
     inferenceManagerServerWorkerServiceAddr: {{ .Values.inferenceManagerServerWorkerServiceAddr }}
     modelManagerServerWorkerServiceAddr: {{ .Values.global.worker.controlPlaneAddr | default .Values.modelManagerServerWorkerServiceAddr }}
     worker:

--- a/deployments/engine/templates/deployment.yaml
+++ b/deployments/engine/templates/deployment.yaml
@@ -28,10 +28,6 @@ spec:
         - run
         - --config
         - /etc/config/config.yaml
-        ports:
-        - name: ollama
-          containerPort: {{ .Values.ollamaPort }}
-          protocol: TCP
         {{- if (gt (int .Values.resources.gpu) 0) }}
         resources:
           limits:

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -21,8 +21,9 @@ global:
 
   controlPlaneAddr: ""
 
-
-ollamaPort: 8080
+ollama:
+  port: 8080
+  keepAlive: 10m
 
 # The following default values work if model-manager-server runs in the same namespace.
 inferenceManagerServerWorkerServiceAddr: inference-manager-server-worker-service-grpc:8082

--- a/engine/cmd/run.go
+++ b/engine/cmd/run.go
@@ -50,10 +50,14 @@ var runCmd = &cobra.Command{
 }
 
 func run(ctx context.Context, c *config.Config) error {
-	ollamaAddr := fmt.Sprintf("0.0.0.0:%d", c.OllamaPort)
+	ollamaAddr := fmt.Sprintf("0.0.0.0:%d", c.Ollama.Port)
 	if err := os.Setenv("OLLAMA_HOST", ollamaAddr); err != nil {
 		return err
 	}
+	if err := os.Setenv("OLLAMA_KEEP_ALIVE", c.Ollama.KeepAlive.String()); err != nil {
+		return err
+	}
+
 	om := ollama.NewManager(ollamaAddr)
 
 	errCh := make(chan error)

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -3,9 +3,30 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// OllamaConfig is the Ollama configuration.
+type OllamaConfig struct {
+	// Port is the port to listen on.
+	Port int `yaml:"port"`
+
+	// KeepAlive is the keep-alive duration for Ollama.
+	// This controls how long Ollama keeps models in GPU memory.
+	KeepAlive time.Duration `yaml:"keepAlive"`
+}
+
+func (c *OllamaConfig) validate() error {
+	if c.Port <= 0 {
+		return fmt.Errorf("port must be greater than 0")
+	}
+	if c.KeepAlive <= 0 {
+		return fmt.Errorf("keepAlive must be greater than 0")
+	}
+	return nil
+}
 
 // S3Config is the S3 configuration.
 type S3Config struct {
@@ -53,7 +74,7 @@ type WorkerConfig struct {
 
 // Config is the configuration.
 type Config struct {
-	OllamaPort int `yaml:"ollamaPort"`
+	Ollama OllamaConfig `yaml:"ollama"`
 
 	ObjectStore ObjectStoreConfig `yaml:"objectStore"`
 
@@ -67,8 +88,8 @@ type Config struct {
 
 // Validate validates the configuration.
 func (c *Config) Validate() error {
-	if c.OllamaPort <= 0 {
-		return fmt.Errorf("ollamaPort must be greater than 0")
+	if err := c.Ollama.validate(); err != nil {
+		return fmt.Errorf("ollama: %s", err)
 	}
 
 	if c.InferenceManagerServerWorkerServiceAddr == "" {


### PR DESCRIPTION
Also consolidate Ollama config in a separate struct to help vLLM migration.

Having a longer keep-alive would help for now to avoid extra memory load time when the same model is used again and again.