### PR TITLE
Make SSE splitting logic more robust

### DIFF
--- a/common/pkg/sse/scanner.go
+++ b/common/pkg/sse/scanner.go
@@ -26,12 +26,8 @@ type Scanner struct {
 // The return values are the number of bytes to advance the input and the next token to return to the user,
 // if any, plus an error, if any.
 func split(data []byte, atEOF bool) (int, []byte, error) {
-	if atEOF {
-		var nextToken []byte
-		if len(data) > 0 {
-			nextToken = data
-		}
-		return len(data), nextToken, nil
+	if len(data) == 0 {
+		return 0, nil, nil
 	}
 
 	// Find a double newline.
@@ -39,6 +35,7 @@ func split(data []byte, atEOF bool) (int, []byte, error) {
 		[]byte("\r\r"),
 		[]byte("\n\n"),
 		[]byte("\r\n\r\n"),
+		[]byte("\n\n\n\n"),
 	}
 	pos := -1
 	var dlen int
@@ -54,5 +51,5 @@ func split(data []byte, atEOF bool) (int, []byte, error) {
 		return pos + dlen, data[0:pos], nil
 	}
 
-	return 0, nil, nil
+	return len(data), data, nil
 }

--- a/common/pkg/sse/scanner_test.go
+++ b/common/pkg/sse/scanner_test.go
@@ -9,23 +9,48 @@ import (
 )
 
 func TestSplit(t *testing.T) {
-	input := `line0
+	tcs := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "single line",
+			input: "line0",
+			want:  []string{"line0"},
+		},
+		{
+			name: "multiple lines",
+			input: `line0
 
 line1
 
 line2
 
-line3`
-	scanner := bufio.NewScanner(bytes.NewReader([]byte(input)))
-	scanner.Buffer(make([]byte, 4096), 4096)
-	scanner.Split(split)
-	var got []string
-	for scanner.Scan() {
-		got = append(got, scanner.Text())
+line3`,
+			want: []string{"line0", "line1", "line2", "line3"},
+		},
+		{
+			name:  "empty lines",
+			input: ``,
+			want:  []string{},
+		},
 	}
-	err := scanner.Err()
-	assert.NoError(t, err)
 
-	want := []string{"line0", "line1", "line2", "line3"}
-	assert.ElementsMatch(t, want, got)
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+
+			scanner := bufio.NewScanner(bytes.NewReader([]byte(tc.input)))
+			scanner.Buffer(make([]byte, 4096), 4096)
+			scanner.Split(split)
+			var got []string
+			for scanner.Scan() {
+				got = append(got, scanner.Text())
+			}
+			err := scanner.Err()
+			assert.NoError(t, err)
+
+			assert.ElementsMatch(t, tc.want, got)
+		})
+	}
 }


### PR DESCRIPTION
Fix a bug where the split logic doesn't handle a case where atEOF is true but the data contains a double-new-lines.