### PR TITLE
Fix deepseek-coder support in Ollama model file

### DIFF
--- a/engine/internal/ollama/manager.go
+++ b/engine/internal/ollama/manager.go
@@ -221,7 +221,7 @@ PARAMETER stop <|start_header_id|>
 PARAMETER stop <|end_header_id|>
 PARAMETER stop <|eot_id|>`, nil
 
-	case name == "deepseek-ai-deepseek-coder-6.7b-base":
+	case strings.HasPrefix(name, "deepseek-ai-deepseek-coder-6.7b-base"):
 		// Output of "ollama show deepseek-coder --modelfile".
 		return `
 TEMPLATE "{{ .System }}


### PR DESCRIPTION
Use the string match to support the quantized model (= a model name with the "-q4" suffix).