### PR TITLE
Schedule a task to an engine that has the least number of running tasks

### DIFF
--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -23,27 +23,26 @@ func New() *R {
 	}
 }
 
-// GetEngineForModel returns the engine ID for the given model.
-func (r *R) GetEngineForModel(ctx context.Context, modelID, tenantID string) (string, error) {
+// GetEnginesForModel returns the engine IDs for the given model.
+func (r *R) GetEnginesForModel(ctx context.Context, modelID, tenantID string) ([]string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	m, ok := r.mapsByTenantID[tenantID]
 	if !ok {
-		return "", fmt.Errorf("tenant %q not found", tenantID)
+		return nil, fmt.Errorf("tenant %q not found", tenantID)
 	}
 
 	routes := m.getRoute(model{id: modelID})
 	if len(routes) != 0 {
-		// TODO(guangrui): handle load balance.
-		return routes[0], nil
+		return routes, nil
 	}
 
 	engine, err := m.findLeastLoadedEngine()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	m.addRoute(model{id: modelID}, engine)
-	return engine, nil
+	return []string{engine}, nil
 }
 
 // AddOrUpdateEngine adds or updates the engine with the given model IDs.

--- a/server/internal/router/router_test.go
+++ b/server/internal/router/router_test.go
@@ -38,11 +38,11 @@ func TestGetEngineForModel(t *testing.T) {
 	r := New()
 	r.AddOrUpdateEngine("engine0", tenantID, []string{"model1"})
 
-	engineID, err := r.GetEngineForModel(context.Background(), "model1", tenantID)
+	engineIDs, err := r.GetEnginesForModel(context.Background(), "model1", tenantID)
 	assert.NoError(t, err)
-	assert.Equal(t, "engine0", engineID)
+	assert.ElementsMatch(t, []string{"engine0"}, engineIDs)
 
-	_, err = r.GetEngineForModel(context.Background(), "model2", tenantID)
+	_, err = r.GetEnginesForModel(context.Background(), "model2", tenantID)
 	assert.NoError(t, err)
-	assert.Equal(t, "engine0", engineID)
+	assert.ElementsMatch(t, []string{"engine0"}, engineIDs)
 }


### PR DESCRIPTION
When there is more than one engine that has a target model, pick up the least loaded one.