### PR TITLE
Tweak the CPU allocation of engine

### DIFF
--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -66,10 +66,10 @@ serviceAccount:
 
 resources:
   requests:
-    cpu: "250m"
+    cpu: "1000m"
     memory: "500Mi"
-  limits:
-    cpu: "250m"
+  # Do not specify limits as it varies on model and SLO requirements.
+  # Also most cases a GPU node is dedicated to the engine.
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
250 millicores seems too small as "ollama list" is getting slow.

Set the request to 1 core and remove the limit. This is mostly Ok as the GPU node is dedicated to engine.