### PR TITLE
Do not crash when inference-manager-server is unavailable

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
       numGpus: {{ .Values.vllm.numGpus }}
     llmEngine: {{ .Values.llmEngine }}
     llmPort: {{ .Values.llmPort }}
+    healthPort: {{ .Values.healthPort }}
     {{- with .Values.preloadedModelIds }}
     preloadedModelIds:
       {{- toYaml . | nindent 6 }}

--- a/deployments/engine/templates/deployment.yaml
+++ b/deployments/engine/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         - name: llm
           containerPort: {{ .Values.llmPort }}
           protocol: TCP
+        - name: health
+          containerPort: {{ .Values.healthPort }}
+          protocol: TCP
         env:
         {{- with .Values.global.awsSecret }}
         {{- if .name }}
@@ -72,6 +75,8 @@ spec:
           mountPath: /tmp
         - name: tmp
           mountPath: /.ollama
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       {{- with .Values.nodeSelector }}

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -29,6 +29,7 @@ vllm:
 
 llmEngine: ollama
 llmPort: 8080
+healthPort: 8081
 
 preloadedModelIds:
 
@@ -95,3 +96,12 @@ persistentVolume:
 
   volumeBindingMode:
   selector:
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: health
+    scheme: HTTP
+  initialDelaySeconds: 3
+  failureThreshold: 5
+  timeoutSeconds: 3

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -87,6 +87,8 @@ type Config struct {
 	// LLMPort is the port llm listens on.
 	LLMPort int `yaml:"llmPort"`
 
+	HealthPort int `yaml:"healthPort"`
+
 	ObjectStore ObjectStoreConfig `yaml:"objectStore"`
 
 	// PreloadedModelIDs is a list of model IDs to preload. These models are downloaded locally
@@ -103,6 +105,10 @@ type Config struct {
 
 // Validate validates the configuration.
 func (c *Config) Validate() error {
+	if c.HealthPort <= 0 {
+		return fmt.Errorf("healthPort must be greater than 0")
+	}
+
 	if c.InferenceManagerServerWorkerServiceAddr == "" {
 		return fmt.Errorf("inference manager server worker service address must be set")
 	}

--- a/engine/internal/health/health.go
+++ b/engine/internal/health/health.go
@@ -1,0 +1,47 @@
+package health
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// NewProbeHandler returns a new ProbeHandler.
+func NewProbeHandler() *ProbeHandler {
+	return &ProbeHandler{}
+}
+
+type probe interface {
+	IsReady() (bool, string)
+}
+
+// ProbeHandler aggregates health probers.
+type ProbeHandler struct {
+	probes []probe
+}
+
+// AddProbe adds a health prober.
+func (h *ProbeHandler) AddProbe(p probe) {
+	h.probes = append(h.probes, p)
+}
+
+// ProbeHandler writes a result of the health probe.
+func (h *ProbeHandler) ProbeHandler(resp http.ResponseWriter, _ *http.Request) {
+	var msgs []string
+
+	for _, p := range h.probes {
+		if r, msg := p.IsReady(); !r {
+			msgs = append(msgs, msg)
+		}
+	}
+
+	if len(msgs) > 0 {
+		http.Error(resp, strings.Join(msgs, ","), http.StatusServiceUnavailable)
+		return
+	}
+
+	if _, err := fmt.Fprint(resp, "ok"); err != nil {
+		log.Printf("Failed to write health response: %s", err)
+	}
+}

--- a/engine/internal/manager/manager.go
+++ b/engine/internal/manager/manager.go
@@ -18,4 +18,6 @@ type M interface {
 	WaitForReady() error
 	// DeleteModel deletes the model.
 	DeleteModel(ctx context.Context, modelName string) error
+
+	IsReady() (bool, string)
 }

--- a/engine/internal/vllm/manager.go
+++ b/engine/internal/vllm/manager.go
@@ -14,18 +14,18 @@ import (
 // New returns a new Manager.
 func New(c *config.Config) *Manager {
 	return &Manager{
-		host:   "0.0.0.0",
-		port:   c.LLMPort,
-		model:  c.VLLM.Model,
+		host:    "0.0.0.0",
+		port:    c.LLMPort,
+		model:   c.VLLM.Model,
 		numGPUs: c.VLLM.NumGPUs,
 	}
 }
 
 // Manager manages the Ollama service.
 type Manager struct {
-	host   string
-	port   int
-	model  string
+	host    string
+	port    int
+	model   string
 	numGPUs int
 }
 
@@ -72,4 +72,11 @@ func (m *Manager) runCommand(args []string) error {
 func (m *Manager) DeleteModel(ctx context.Context, modelName string) error {
 	log.Printf("DeleteModel is not implemented\n")
 	return nil
+}
+
+// IsReady returns true if the processor is ready. If not,
+// it returns a message describing why it is not ready.
+func (m *Manager) IsReady() (bool, string) {
+	// TODO(kenji): Implement this.
+	return true, ""
 }


### PR DESCRIPTION
It can easily take more than several minutes to download & load large models. It is better to avoid a pod crash when the server is unreachable for a short period of time.