### PR TITLE
Increase the default keep alive to 96 hours

### DIFF
--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -22,7 +22,9 @@ global:
   controlPlaneAddr: ""
 
 ollama:
-  keepAlive: 10m
+  # Keep models in memory for a long period of time as we don't want end users to
+  # hit slowness due to GPU memory loading.
+  keepAlive: 96h
 
 vllm:
   numGpus: 1


### PR DESCRIPTION
This can be longer. Given that loading a large model like llama3.1 70B is slow, we would like to avoid end users from hitting the model loading as much as possible.