### PR TITLE
Update model templtes when cached models are found

### DIFF
--- a/engine/internal/manager/manager.go
+++ b/engine/internal/manager/manager.go
@@ -19,5 +19,7 @@ type M interface {
 	// DeleteModel deletes the model.
 	DeleteModel(ctx context.Context, modelName string) error
 
+	UpdateModelTemplateToLatest(modelname string) error
+
 	IsReady() (bool, string)
 }

--- a/engine/internal/modelsyncer/syncer_test.go
+++ b/engine/internal/modelsyncer/syncer_test.go
@@ -179,6 +179,10 @@ func (n *fakeOllamaManager) DeleteModel(ctx context.Context, modelName string) e
 	return nil
 }
 
+func (n *fakeOllamaManager) UpdateModelTemplateToLatest(modelName string) error {
+	return nil
+}
+
 type noopS3Client struct {
 }
 

--- a/engine/internal/ollama/manager.go
+++ b/engine/internal/ollama/manager.go
@@ -106,6 +106,21 @@ func (m *Manager) WaitForReady() error {
 	}
 }
 
+// UpdateModelTemplateToLatest updates the model template to the latest.
+func (m *Manager) UpdateModelTemplateToLatest(modelName string) error {
+	// TODO(kenji): Update only when there is actual delta. It requires a
+	// non-trival amount of work as Ollama makes modification to the original modelfile content
+	// (e.g., add comments).
+	log.Printf("Recreating model %q with the updated template.\n", modelName)
+	ms := &manager.ModelSpec{
+		From: modelName,
+	}
+	if err := m.CreateNewModel(modelName, ms); err != nil {
+		return fmt.Errorf("create new model: %s", err)
+	}
+	return nil
+}
+
 func (m *Manager) runCommand(args []string) error {
 	log.Printf("Running Ollama command: %v", args)
 	cmd := exec.Command("ollama", args...)

--- a/engine/internal/vllm/manager.go
+++ b/engine/internal/vllm/manager.go
@@ -74,6 +74,12 @@ func (m *Manager) DeleteModel(ctx context.Context, modelName string) error {
 	return nil
 }
 
+// UpdateModelTemplateToLatest updates the model template to the latest.
+func (m *Manager) UpdateModelTemplateToLatest(modelName string) error {
+	log.Printf("UpdateModelTemplateToLatest is not implemented\n")
+	return nil
+}
+
 // IsReady returns true if the processor is ready. If not,
 // it returns a message describing why it is not ready.
 func (m *Manager) IsReady() (bool, string) {


### PR DESCRIPTION
This is neccessary when we make changes to model templates (e.g., context length).