### PR TITLE
Add a force-spreading option

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   config.yaml: |
     ollama:
       keepAlive: {{ .Values.ollama.keepAlive }}
+      forceSpreading: {{ .Values.ollama.forceSpreading }}
     vllm:
       model: {{ .Values.vllm.model }}
       numGpus: {{ .Values.vllm.numGpus }}

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -25,6 +25,14 @@ ollama:
   # Keep models in memory for a long period of time as we don't want end users to
   # hit slowness due to GPU memory loading.
   keepAlive: 96h
+  # Ollama's current GPU spreading policiy does not handle multiple H100s well.
+  # Enable force-spreading to work around this.
+  #
+  # Please note that there is a certain performance penality when a model can
+  # fit in a single GPU.
+  #
+  # See https://github.com/ollama/ollama/issues/5494.
+  forceSpreading: true
 
 vllm:
   numGpus: 1

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -20,6 +20,9 @@ type OllamaConfig struct {
 	// KeepAlive is the keep-alive duration for Ollama.
 	// This controls how long Ollama keeps models in GPU memory.
 	KeepAlive time.Duration `yaml:"keepAlive"`
+
+	// ForceSpreading is true if the models should be spread across all GPUs.
+	ForceSpreading bool `yaml:"forceSpreading"`
 }
 
 func (c *OllamaConfig) validate() error {


### PR DESCRIPTION
Ollama currently doesn't handle multiple H100s (https://github.com/ollama/ollama/issues/5494).

This is a workaround described in the above ticket.