### PR TITLE
Add maxConcurrentRequests instead of ollama.numParallel

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -8,8 +8,8 @@ data:
   config.yaml: |
     ollama:
       keepAlive: {{ .Values.ollama.keepAlive }}
+      numParallel: {{ .Values.maxConcurrentRequests }}
       forceSpreading: {{ .Values.ollama.forceSpreading }}
-      numParallel: {{ .Values.ollama.numParallel }}
       debug: {{ .Values.ollama.debug }}
     vllm:
       model: {{ .Values.vllm.model }}

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -25,8 +25,6 @@ ollama:
   # Keep models in memory for a long period of time as we don't want end users to
   # hit slowness due to GPU memory loading.
   keepAlive: 96h
-  # numParallel sets the number of parallel model requests.
-  numParallel: 0
   # If set, Ollama attemts to all GPUs in a node.
   # Setting this to true was mentioned in https://github.com/ollama/ollama/issues/5494
   # to support multiple H100s, but this setting didn't help.
@@ -35,6 +33,9 @@ ollama:
 
 vllm:
   numGpus: 1
+
+# maxConcurentRequests is the maximun number of requests procssed in parallel.
+maxConcurrentRequests: 0
 
 llmEngine: ollama
 llmPort: 8080


### PR DESCRIPTION
ollama.numParallel is something end users change, and I wanted to avoid exposing the internal implementation details.