### PR TITLE
Add back ollama keep alive logic

### DIFF
--- a/engine/internal/ollama/env.go
+++ b/engine/internal/ollama/env.go
@@ -10,6 +10,10 @@ import (
 
 // SetEnvVarsFromConfig sets environment variables from the given configuration.
 func SetEnvVarsFromConfig(c config.OllamaConfig) error {
+	if err := os.Setenv("OLLAMA_KEEP_ALIVE", c.KeepAlive.String()); err != nil {
+		return err
+	}
+
 	if c.NumParallel > 0 {
 		log.Printf("Setting Ollama NumParallel %d\n", c.NumParallel)
 		if err := os.Setenv("OLLAMA_NUM_PARALLEL", strconv.Itoa(c.NumParallel)); err != nil {


### PR DESCRIPTION
This was accidentally removed with
https://github.com/llm-operator/inference-manager/pull/206