### PR TITLE
Check if the service is reachable before making it ready

### DIFF
--- a/engine/internal/processor/processor.go
+++ b/engine/internal/processor/processor.go
@@ -253,6 +253,8 @@ func (p *P) processTask(
 		return fmt.Errorf("build request: %s", err)
 	}
 
+	log.Printf("Sending request to the LLM server: %s\n", req.URL)
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to send request to the LLM server: %s", err)

--- a/engine/internal/runtime/manager.go
+++ b/engine/internal/runtime/manager.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -185,7 +187,18 @@ func (m *Manager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 	}
 
 	if sts.Status.ReadyReplicas > 0 && m.isPending(modelID) {
-		m.markRuntimeReady(modelID, m.rtClient.GetAddress(sts.Name))
+		addr := m.rtClient.GetAddress(sts.Name)
+		// Double check if the statefulset is reachable as it might take some time for the service is being updated.
+		req := &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{Scheme: "http", Host: addr},
+		}
+		if _, err := http.DefaultClient.Do(req); err != nil {
+			log.Error(err, "Failed to reach the runtime")
+			return ctrl.Result{}, err
+		}
+
+		m.markRuntimeReady(modelID, addr)
 		log.Info("Runtime is ready")
 	}
 	return ctrl.Result{}, nil


### PR DESCRIPTION
We got a timeout error or a connection-refused error when a request is sent immediately after a statefulset becomes reachable.

This can be because it takes some time until an endpoint is created and kube-proxy updates ipfilter.

Checking the actual reachability will be needed.