### PR TITLE
Use a fix dir for ollama payload

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -36,6 +36,7 @@ data:
       numParallel: {{ .Values.maxConcurrentRequests }}
       forceSpreading: {{ .Values.ollama.forceSpreading }}
       debug: {{ .Values.ollama.debug }}
+      runnersDir: {{ .Values.ollama.runnersDir }}
     vllm:
       model: {{ .Values.vllm.model }}
       numGpus: {{ .Values.vllm.numGpus }}

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -62,6 +62,7 @@ ollama:
   # to support multiple H100s, but this setting didn't help.
   forceSpreading: false
   debug: false
+  runnersDir: /tmp/ollama-runners
 
 vllm:
   numGpus: 1

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -28,6 +28,8 @@ type OllamaConfig struct {
 	ForceSpreading bool `yaml:"forceSpreading"`
 
 	Debug bool `yaml:"debug"`
+
+	RunnersDir string `yaml:"runnersDir"`
 }
 
 func (c *OllamaConfig) validate() error {
@@ -36,6 +38,9 @@ func (c *OllamaConfig) validate() error {
 	}
 	if c.NumParallel < 0 {
 		return fmt.Errorf("numParallel must be non-negative")
+	}
+	if c.RunnersDir == "" {
+		return fmt.Errorf("runnerDir must be set")
 	}
 	return nil
 }

--- a/engine/internal/ollama/env.go
+++ b/engine/internal/ollama/env.go
@@ -10,6 +10,15 @@ import (
 
 // SetEnvVarsFromConfig sets environment variables from the given configuration.
 func SetEnvVarsFromConfig(c config.OllamaConfig) error {
+	// Ollama creaets a payload in a temporary directory by default, and a new temporary directory is created
+	// whenever Ollama restarts. This is a problem when a persistent volume is mounted.
+	// To avoid this, we set the directory to a fixed path.
+	//
+	// TODO(kenji): Make sure there is no issue when multiple pods start at the same time.
+	if err := os.Setenv("OLLAMA_RUNNERS_DIR", c.RunnersDir); err != nil {
+		return err
+	}
+
 	if err := os.Setenv("OLLAMA_KEEP_ALIVE", c.KeepAlive.String()); err != nil {
 		return err
 	}

--- a/engine/internal/runtime/ollama_client.go
+++ b/engine/internal/runtime/ollama_client.go
@@ -48,6 +48,12 @@ func (o *ollamaClient) DeployRuntime(ctx context.Context, modelID string) error 
 	envs := []*corev1apply.EnvVarApplyConfiguration{
 		corev1apply.EnvVar().WithName("OLLAMA_MODELS").WithValue(modelDir),
 		corev1apply.EnvVar().WithName("OLLAMA_KEEP_ALIVE").WithValue(o.config.KeepAlive.String()),
+		// Ollama creaets a payload in a temporary directory by default, and a new temporary directory is created
+		// whenever Ollama restarts. This is a problem when a persistent volume is mounted.
+		// To avoid this, we set the directory to a fixed path.
+		//
+		// TODO(kenji): Make sure there is no issue when multiple pods start at the same time.
+		corev1apply.EnvVar().WithName("OLLAMA_RUNNERS_DIR").WithValue(o.config.RunnersDir),
 	}
 	if o.config.NumParallel > 0 {
 		envs = append(envs, corev1apply.EnvVar().WithName("OLLAMA_NUM_PARALLEL").WithValue(strconv.Itoa(o.config.NumParallel)))


### PR DESCRIPTION
Ollama creaets a payload in a temporary directory by default, and a new temporary directory is created whenever Ollama restarts. This is a problem when a persistent volume is mounted. To avoid this, we set the directory to a fixed path.