### PR TITLE
Be able to use consistent format for model IDs

### DIFF
--- a/engine/cmd/alpha.go
+++ b/engine/cmd/alpha.go
@@ -81,7 +81,7 @@ func alphaRun(ctx context.Context, c *config.Config, ns string, lv int) error {
 	case runtime.RuntimeNameOllama:
 		rtClient = runtime.NewOllamaClient(mgr.GetClient(), ns, c.Runtime, c.Ollama)
 	case runtime.RuntimeNameVLLM:
-		rtClient = runtime.NewVLLMClient(mgr.GetClient(), ns, c.Runtime, c.VLLM, c.ModelContextLengths)
+		rtClient = runtime.NewVLLMClient(mgr.GetClient(), ns, c.Runtime, c.VLLM, c.FormattedModelContextLengths())
 	default:
 		return fmt.Errorf("invalid llm engine: %q", c.LLMEngine)
 	}
@@ -123,9 +123,9 @@ func alphaRun(ctx context.Context, c *config.Config, ns string, lv int) error {
 		return p.Run(ctx)
 	})
 
-	if len(c.PreloadedModelIDs) > 0 {
-		bootLog.Info("Preloading models", "count", len(c.PreloadedModelIDs))
-		if err := preloadModels(ctx, rtManager, c.PreloadedModelIDs); err != nil {
+	if ids := c.FormattedPreloadedModelIDs(); len(ids) > 0 {
+		bootLog.Info("Preloading models", "count", len(ids))
+		if err := preloadModels(ctx, rtManager, ids); err != nil {
 			return err
 		}
 	}

--- a/engine/cmd/pull.go
+++ b/engine/cmd/pull.go
@@ -71,7 +71,7 @@ func pull(ctx context.Context, o opts, c config.Config) error {
 			log.Printf("Model %s is already registered", o.modelID)
 			return nil
 		}
-		omgr := ollama.New(c.ModelContextLengths)
+		omgr := ollama.New(c.FormattedModelContextLengths())
 		go func() { done <- omgr.Run() }()
 		mgr = omgr
 	case runtime.RuntimeNameVLLM:

--- a/engine/cmd/run.go
+++ b/engine/cmd/run.go
@@ -77,7 +77,7 @@ func run(ctx context.Context, c *config.Config) error {
 			return err
 		}
 
-		m = ollama.New(c.ModelContextLengths)
+		m = ollama.New(c.FormattedModelContextLengths())
 	case llmkind.VLLM:
 		m = vllm.New(c, "")
 	default:
@@ -146,7 +146,7 @@ func run(ctx context.Context, c *config.Config) error {
 		errCh <- p.Run(ctx)
 	}()
 
-	if ids := c.PreloadedModelIDs; len(ids) > 0 {
+	if ids := c.FormattedPreloadedModelIDs(); len(ids) > 0 {
 		go func() {
 			log.Printf("Preloading %d model(s)", len(ids))
 			ctx := auth.AppendWorkerAuthorization(ctx)

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -211,6 +211,28 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// FormattedModelContextLengths returns the model context lengths keyed by formatted model IDs.
+//
+// model-manager-loader convers "/" in the model ID to "-". Do the same conversion here
+// so that end users can use the consistent forma.
+func (c *Config) FormattedModelContextLengths() map[string]int {
+	lens := map[string]int{}
+	for id, l := range c.ModelContextLengths {
+		id = strings.ReplaceAll(id, "/", "-")
+		lens[id] = l
+	}
+	return lens
+}
+
+// FormattedPreloadedModelIDs returns a formatted IDs of models to be preloaded.
+func (c *Config) FormattedPreloadedModelIDs() []string {
+	var ids []string
+	for _, id := range c.PreloadedModelIDs {
+		ids = append(ids, strings.ReplaceAll(id, "/", "-"))
+	}
+	return ids
+}
+
 // Parse parses the configuration file at the given path, returning a new
 // Config struct.
 func Parse(path string) (Config, error) {

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -67,6 +67,15 @@ type RuntimeConfig struct {
 	DefaultResources Resources            `yaml:"defaultResources"`
 }
 
+// FormattedModelResources returns the resources keyed by formatted model IDs.
+func (c *RuntimeConfig) FormattedModelResources() map[string]Resources {
+	res := map[string]Resources{}
+	for id, r := range c.ModelResources {
+		res[formatModelID(id)] = r
+	}
+	return res
+}
+
 // Resources is the resources configuration.
 type Resources struct {
 	Requests map[string]string `yaml:"requests"`
@@ -212,14 +221,11 @@ func (c *Config) Validate() error {
 }
 
 // FormattedModelContextLengths returns the model context lengths keyed by formatted model IDs.
-//
-// model-manager-loader convers "/" in the model ID to "-". Do the same conversion here
-// so that end users can use the consistent forma.
 func (c *Config) FormattedModelContextLengths() map[string]int {
 	lens := map[string]int{}
 	for id, l := range c.ModelContextLengths {
-		id = strings.ReplaceAll(id, "/", "-")
-		lens[id] = l
+
+		lens[formatModelID(id)] = l
 	}
 	return lens
 }
@@ -228,9 +234,15 @@ func (c *Config) FormattedModelContextLengths() map[string]int {
 func (c *Config) FormattedPreloadedModelIDs() []string {
 	var ids []string
 	for _, id := range c.PreloadedModelIDs {
-		ids = append(ids, strings.ReplaceAll(id, "/", "-"))
+		ids = append(ids, formatModelID(id))
 	}
 	return ids
+}
+
+func formatModelID(id string) string {
+	// model-manager-loader convers "/" in the model ID to "-". Do the same conversion here
+	// so that end users can use the consistent format.
+	return strings.ReplaceAll(id, "/", "-")
 }
 
 // Parse parses the configuration file at the given path, returning a new

--- a/engine/internal/config/config_test.go
+++ b/engine/internal/config/config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormattedModelContextLengths(t *testing.T) {
+	c := Config{
+		ModelContextLengths: map[string]int{
+			"google/gemma-2b-it-q4": 10,
+		},
+	}
+	got := c.FormattedModelContextLengths()
+	want := map[string]int{
+		"google-gemma-2b-it-q4": 10,
+	}
+	assert.True(t, reflect.DeepEqual(got, want), "got: %v, want: %v", got, want)
+}
+
+func TestFormattedPreloadedModelIDs(t *testing.T) {
+	c := Config{
+		PreloadedModelIDs: []string{
+			"google/gemma-2b-it-q4",
+		},
+	}
+	got := c.FormattedPreloadedModelIDs()
+	want := []string{
+		"google-gemma-2b-it-q4",
+	}
+	assert.ElementsMatch(t, got, want)
+}

--- a/engine/internal/runtime/client.go
+++ b/engine/internal/runtime/client.go
@@ -51,7 +51,7 @@ type commonClient struct {
 }
 
 func (c *commonClient) getResouces(modelID string) config.Resources {
-	if res, ok := c.ModelResources[modelID]; ok {
+	if res, ok := c.FormattedModelResources()[modelID]; ok {
 		return res
 	}
 	return c.DefaultResources


### PR DESCRIPTION
Model IDs we use in model-manager-loader contains "/". Allow end users to have the same format in inference-manager-engine.