### PR TITLE
Fix a bug from refactoring in (legacy_)completions.go

### DIFF
--- a/server/internal/server/completions.go
+++ b/server/internal/server/completions.go
@@ -77,6 +77,7 @@ func (s *S) CreateChatCompletion(
 
 	if code, err := s.checkModelAvailability(ctx, createReq.Model); err != nil {
 		http.Error(w, err.Error(), code)
+		return
 	}
 
 	if code, err := s.handleTools(ctx, &createReq); err != nil {

--- a/server/internal/server/legacy_completions.go
+++ b/server/internal/server/legacy_completions.go
@@ -68,6 +68,7 @@ func (s *S) CreateCompletion(
 
 	if code, err := s.checkModelAvailability(ctx, createReq.Model); err != nil {
 		http.Error(w, err.Error(), code)
+		return
 	}
 
 	task, err := infprocessor.NewTask(userInfo.TenantID, toCreateChatCompletionRequest(&createReq), req.Header)


### PR DESCRIPTION
Add a missing 'return' after calling http.Error().