### PR TITLE
Retrieve a model format when creating a statefulset

### DIFF
--- a/engine/internal/runtime/client.go
+++ b/engine/internal/runtime/client.go
@@ -76,7 +76,7 @@ func (c *commonClient) GetAddress(name string) string {
 	return fmt.Sprintf("%s:%d", name, c.servingPort)
 }
 
-type deployRunTimeParams struct {
+type deployRuntimeParams struct {
 	modelID        string
 	initEnvs       []*corev1apply.EnvVarApplyConfiguration
 	envs           []*corev1apply.EnvVarApplyConfiguration
@@ -90,7 +90,7 @@ type deployRunTimeParams struct {
 // deployRuntime deploys the runtime for the given model.
 func (c *commonClient) deployRuntime(
 	ctx context.Context,
-	params deployRunTimeParams,
+	params deployRuntimeParams,
 ) (types.NamespacedName, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Deploying runtime", "model", params.modelID)

--- a/engine/internal/runtime/ollama_client.go
+++ b/engine/internal/runtime/ollama_client.go
@@ -69,7 +69,7 @@ func (o *ollamaClient) DeployRuntime(ctx context.Context, modelID string) (types
 	args := []string{
 		"serve",
 	}
-	return o.deployRuntime(ctx, deployRunTimeParams{
+	return o.deployRuntime(ctx, deployRuntimeParams{
 		modelID:  modelID,
 		initEnvs: initEnvs,
 		envs:     envs,

--- a/engine/internal/runtime/vllm_client_test.go
+++ b/engine/internal/runtime/vllm_client_test.go
@@ -1,11 +1,88 @@
 package runtime
 
 import (
+	"context"
 	"testing"
 
 	"github.com/llm-operator/inference-manager/engine/internal/config"
+	mv1 "github.com/llm-operator/model-manager/api/v1"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 )
+
+func TestDeployRuntimeParams(t *testing.T) {
+
+	commonClient := &commonClient{
+		RuntimeConfig: config.RuntimeConfig{
+			ModelResources: map[string]config.Resources{
+				"TinyLlama-TinyLlama-1.1B-Chat-v1.0": {
+					Limits: map[string]string{
+						"cpu":            "1",
+						"nvidia.com/gpu": "2",
+					},
+				},
+			},
+		},
+	}
+
+	tcs := []struct {
+		name     string
+		modelID  string
+		resp     *mv1.GetBaseModelPathResponse
+		wantArgs []string
+	}{
+		{
+			name:    "both formats",
+			modelID: "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
+			resp: &mv1.GetBaseModelPathResponse{
+				Path: "path",
+				Formats: []mv1.ModelFormat{
+					mv1.ModelFormat_MODEL_FORMAT_GGUF,
+					mv1.ModelFormat_MODEL_FORMAT_HUGGING_FACE,
+				},
+			},
+			wantArgs: []string{
+				"--port", "80",
+				"--model", "/models",
+				"--served-model-name", "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
+				"--chat-template", "\n<|begin_of_text|>\n{% for message in messages %}\n{{'<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n' + message['content'] + '\\n<|eot_id|>\\n'}}\n{% endfor %}\n",
+				"--tensor-parallel-size", "2",
+			},
+		},
+		{
+			name:    "gguf only",
+			modelID: "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
+			resp: &mv1.GetBaseModelPathResponse{
+				Path: "path",
+				Formats: []mv1.ModelFormat{
+					mv1.ModelFormat_MODEL_FORMAT_GGUF,
+				},
+			},
+			wantArgs: []string{
+				"--port", "80",
+				"--model", "/models/TinyLlama-TinyLlama-1.1B-Chat-v1.0.gguf",
+				"--served-model-name", "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
+				"--chat-template", "\n<|begin_of_text|>\n{% for message in messages %}\n{{'<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n' + message['content'] + '\\n<|eot_id|>\\n'}}\n{% endfor %}\n",
+				"--tensor-parallel-size", "2",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &vllmClient{
+				commonClient: commonClient,
+				modelClient: &fakeModelClient{
+					resp: tc.resp,
+				},
+			}
+
+			got, err := v.deployRuntimeParams(context.Background(), tc.modelID)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantArgs, got.args)
+		})
+	}
+}
 
 func TestNumGPUs(t *testing.T) {
 	v := &vllmClient{
@@ -52,4 +129,12 @@ func TestNumGPUs(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+type fakeModelClient struct {
+	resp *mv1.GetBaseModelPathResponse
+}
+
+func (c *fakeModelClient) GetBaseModelPath(ctx context.Context, in *mv1.GetBaseModelPathRequest, opts ...grpc.CallOption) (*mv1.GetBaseModelPathResponse, error) {
+	return c.resp, nil
 }


### PR DESCRIPTION
We used to infer a model format from a model ID, but it didn't work when a model supports multiple formats.

Change the code to retrieve the format from model-manager-server when creating a stratefulset.