### PR TITLE
Do not download the model multiple times (for vLLM)

### DIFF
--- a/engine/internal/vllm/manager_test.go
+++ b/engine/internal/vllm/manager_test.go
@@ -1,0 +1,44 @@
+package vllm
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	mv1 "github.com/llm-operator/model-manager/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownloadAndCreateNewModel(t *testing.T) {
+	// Create a temp dir
+	modelDir, err := os.MkdirTemp("", "model")
+	assert.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(modelDir)
+	}()
+
+	s3Client := &fakeS3Client{}
+	m := New(modelDir, s3Client)
+	resp := &mv1.GetBaseModelPathResponse{
+		Formats: []mv1.ModelFormat{
+			mv1.ModelFormat_MODEL_FORMAT_GGUF,
+		},
+	}
+	err = m.DownloadAndCreateNewModel("model0", resp)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, s3Client.numDownload)
+
+	// Run again.
+	err = m.DownloadAndCreateNewModel("model0", resp)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, s3Client.numDownload)
+}
+
+type fakeS3Client struct {
+	numDownload int
+}
+
+func (c *fakeS3Client) Download(f io.WriterAt, path string) error {
+	c.numDownload++
+	return nil
+}


### PR DESCRIPTION
We have the same mechanism in Ollama, but vLLM didn't have.

Create a file that indicates the completion of download, and do not download again if the file exists.