### PR TITLE
Add an optional servicemonitor for cllecting runtime metrics

### DIFF
--- a/deployments/engine/templates/servicemonitor.yaml
+++ b/deployments/engine/templates/servicemonitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.enableServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "inference-manager-engine.fullname" . }}-runtime
+  labels:
+    {{- include "inference-manager-engine.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: runtime
+  endpoints:
+  - port: http
+{{- end }}

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -164,3 +164,5 @@ readinessProbe:
   initialDelaySeconds: 3
   failureThreshold: 5
   timeoutSeconds: 3
+
+enableServiceMonitor: false


### PR DESCRIPTION
vLLM exports Prometheus metrics (https://github.com/vllm-project/vllm/blob/main/examples/production_monitoring/README.md), which we can set up a ServiceMonitor to collect metrics.