### PR TITLE
Do not allocate GPU to the engine pod

### DIFF
--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -123,10 +123,6 @@ resources:
   requests:
     cpu: "1000m"
     memory: "500Mi"
-  # Do not specify CPU/memory limits as it varies on model and SLO requirements.
-  # Also most cases a GPU node is dedicated to the engine.
-  limits:
-    nvidia.com/gpu: 1
 
 podSecurityContext:
   fsGroup: 2000


### PR DESCRIPTION
We no longer need to allocate GPU as model pods have GPUs instead.