### PR TITLE
Do not append worker authorization in modelFilePath()

### DIFF
--- a/engine/cmd/run.go
+++ b/engine/cmd/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/llm-operator/inference-manager/engine/internal/processor"
 	"github.com/llm-operator/inference-manager/engine/internal/runtime"
 	mv1 "github.com/llm-operator/model-manager/api/v1"
+	"github.com/llm-operator/rbac-manager/pkg/auth"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -159,7 +160,9 @@ func run(ctx context.Context, c *config.Config, ns string, lv int) error {
 }
 
 func preloadModels(ctx context.Context, rtManager *runtime.Manager, ids []string) error {
+	ctx = auth.AppendWorkerAuthorization(ctx)
 	const preloadingParallelism = 3
+
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(preloadingParallelism)
 	for _, id := range ids {

--- a/engine/internal/runtime/vllm_client.go
+++ b/engine/internal/runtime/vllm_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/llm-operator/inference-manager/engine/internal/config"
 	"github.com/llm-operator/inference-manager/engine/internal/vllm"
 	mv1 "github.com/llm-operator/model-manager/api/v1"
-	"github.com/llm-operator/rbac-manager/pkg/auth"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -149,7 +148,7 @@ func (v *vllmClient) numGPUs(modelID string) (int, error) {
 
 func (v *vllmClient) modelFilePath(ctx context.Context, modelID string) (string, error) {
 	// TODO(kenji): Support non-base model.
-	resp, err := v.modelClient.GetBaseModelPath(auth.AppendWorkerAuthorization(ctx), &mv1.GetBaseModelPathRequest{
+	resp, err := v.modelClient.GetBaseModelPath(ctx, &mv1.GetBaseModelPathRequest{
 		Id: modelID,
 	})
 	if err != nil {


### PR DESCRIPTION
This doesn't work when the function is called from processor.P as the context already has a worker authorization (and adding it again breaks gRPC).

Instead of appending in modelFilePath(), do this in preload().