### PR TITLE
Use distroless for a base image for inference-manager-engine

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -62,6 +62,7 @@ jobs:
         file: ./build/engine/Dockerfile
         push: true
         platforms: linux/amd64,linux/arm64
+        target: base-distroless
         tags: |
           public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-engine:${{ needs.update-tag.outputs.new_version }}
           public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-engine:latest
@@ -71,9 +72,10 @@ jobs:
         file: ./build/server/Dockerfile
         push: true
         platforms: linux/amd64,linux/arm64
+        target: base-ollama
         tags: |
-          public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-server:${{ needs.update-tag.outputs.new_version }}
-          public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-server:latest
+          public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-server:ollama-${{ needs.update-tag.outputs.new_version }}
+          public.ecr.aws/v8n3t7y5/llm-operator/inference-manager-server:ollama-latest
 
   publish-helm-chart:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,8 @@ build-docker-server:
 
 .PHONY: build-docker-engine
 build-docker-engine:
-	docker build --build-arg TARGETARCH=amd64 -t llm-operator/inference-manager-engine:latest -f build/engine/Dockerfile .
+	docker build --build-arg TARGETARCH=amd64 --target base-distroless -t llm-operator/inference-manager-engine:latest -f build/engine/Dockerfile .
+
+.PHONY: build-docker-engine-base-ollama
+build-docker-engine-base-ollama:
+	docker build --build-arg TARGETARCH=amd64 --target base-ollama -t llm-operator/inference-manager-engine:latest -f build/engine/Dockerfile .

--- a/build/engine/Dockerfile
+++ b/build/engine/Dockerfile
@@ -14,7 +14,16 @@ RUN --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,id=inference-manager,sharing=locked,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on make build-engine
 
-FROM --platform=$BUILDPLATFORM ollama/ollama:0.3.6
+FROM --platform=$BUILDPLATFORM ollama/ollama:0.3.6 AS base-ollama
+ARG TARGETARCH
+
+WORKDIR /run
+
+COPY --from=builder /workspace/bin/engine .
+
+ENTRYPOINT ["./engine"]
+
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot AS base-distroless
 ARG TARGETARCH
 
 WORKDIR /run


### PR DESCRIPTION
Still build an image with Ollama base so that we can fall back to the previous behavior, but change the default image to not include Ollama anymore.