### PR TITLE
Factor out the model download logic to a separate package

### DIFF
--- a/engine/internal/modeldownloader/modeldownloader.go
+++ b/engine/internal/modeldownloader/modeldownloader.go
@@ -1,0 +1,95 @@
+package modeldownloader
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/llm-operator/inference-manager/engine/internal/huggingface"
+	mv1 "github.com/llm-operator/model-manager/api/v1"
+)
+
+type s3Client interface {
+	Download(ctx context.Context, f io.WriterAt, path string) error
+}
+
+// New returns a new Manager.
+func New(modelDir string, s3Client s3Client) *D {
+	return &D{
+		modelDir: modelDir,
+		s3Client: s3Client,
+	}
+}
+
+// D is a downloader.
+type D struct {
+	modelDir string
+
+	s3Client s3Client
+}
+
+// Download downloads the model.
+func (d *D) Download(
+	ctx context.Context,
+	modelName string,
+	resp *mv1.GetBaseModelPathResponse,
+	format mv1.ModelFormat,
+	destPath string,
+) error {
+	// Check if the completion indication file exists. If so, download should have been completed with a previous run. Do not download again.
+	completionDir := filepath.Join(d.modelDir, modelName)
+	if err := os.MkdirAll(completionDir, 0755); err != nil {
+		return err
+	}
+	completionIndicationFile := filepath.Join(completionDir, "completed.txt")
+
+	if _, err := os.Stat(completionIndicationFile); err == nil {
+		log.Printf("The model has already been downloaded. Skipping the download.\n")
+		return nil
+	}
+
+	switch format {
+	case mv1.ModelFormat_MODEL_FORMAT_GGUF:
+		log.Printf("Downloading the GGUF model from %q\n", resp.GgufModelPath)
+		f, err := os.Create(destPath)
+		if err != nil {
+			return err
+		}
+		if err := d.s3Client.Download(ctx, f, resp.GgufModelPath); err != nil {
+			return fmt.Errorf("download: %s", err)
+		}
+		log.Printf("Downloaded the model to %q\n", f.Name())
+		if err := f.Close(); err != nil {
+			return err
+		}
+	case mv1.ModelFormat_MODEL_FORMAT_HUGGING_FACE:
+		log.Printf("Downloading the Hugging Face model from %q\n", resp.Path)
+		if err := os.MkdirAll(destPath, 0755); err != nil {
+			return fmt.Errorf("create directory: %s", err)
+		}
+		if err := huggingface.DownloadModelFiles(ctx, d.s3Client, resp.Path, destPath); err != nil {
+			return fmt.Errorf("download: %s", err)
+		}
+		log.Printf("Downloaded the model to %q\n", destPath)
+	default:
+		return fmt.Errorf("unsupported model format: %s", format)
+	}
+
+	// Create a file that indicates the completion of model download.
+	f, err := os.Create(completionIndicationFile)
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(f, "aa"); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/engine/internal/modeldownloader/modeldownloader_test.go
+++ b/engine/internal/modeldownloader/modeldownloader_test.go
@@ -1,16 +1,17 @@
-package vllm
+package modeldownloader
 
 import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	mv1 "github.com/llm-operator/model-manager/api/v1"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDownloadAndCreateNewModel(t *testing.T) {
+func TestDownload(t *testing.T) {
 	// Create a temp dir
 	modelDir, err := os.MkdirTemp("", "model")
 	assert.NoError(t, err)
@@ -20,18 +21,19 @@ func TestDownloadAndCreateNewModel(t *testing.T) {
 
 	ctx := context.Background()
 	s3Client := &fakeS3Client{}
-	m := New(modelDir, s3Client)
+	d := New(modelDir, s3Client)
 	resp := &mv1.GetBaseModelPathResponse{
 		Formats: []mv1.ModelFormat{
 			mv1.ModelFormat_MODEL_FORMAT_GGUF,
 		},
 	}
-	err = m.DownloadAndCreateNewModel(ctx, "model0", resp)
+	destPath := filepath.Join(modelDir, "model.gguf")
+	err = d.Download(ctx, "model0", resp, mv1.ModelFormat_MODEL_FORMAT_GGUF, destPath)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, s3Client.numDownload)
 
 	// Run again.
-	err = m.DownloadAndCreateNewModel(ctx, "model0", resp)
+	err = d.Download(ctx, "model0", resp, mv1.ModelFormat_MODEL_FORMAT_GGUF, destPath)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, s3Client.numDownload)
 }

--- a/engine/internal/runtime/vllm_client_test.go
+++ b/engine/internal/runtime/vllm_client_test.go
@@ -43,7 +43,7 @@ func TestDeployRuntimeParams(t *testing.T) {
 			},
 			wantArgs: []string{
 				"--port", "80",
-				"--model", "/models",
+				"--model", "/models/TinyLlama-TinyLlama-1.1B-Chat-v1.0",
 				"--served-model-name", "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
 				"--chat-template", "\n<|begin_of_text|>\n{% for message in messages %}\n{{'<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n' + message['content'] + '\\n<|eot_id|>\\n'}}\n{% endfor %}\n",
 				"--tensor-parallel-size", "2",
@@ -60,7 +60,7 @@ func TestDeployRuntimeParams(t *testing.T) {
 			},
 			wantArgs: []string{
 				"--port", "80",
-				"--model", "/models/TinyLlama-TinyLlama-1.1B-Chat-v1.0.gguf",
+				"--model", "/models/TinyLlama-TinyLlama-1.1B-Chat-v1.0/model.gguf",
 				"--served-model-name", "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
 				"--chat-template", "\n<|begin_of_text|>\n{% for message in messages %}\n{{'<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n' + message['content'] + '\\n<|eot_id|>\\n'}}\n{% endfor %}\n",
 				"--tensor-parallel-size", "2",

--- a/engine/internal/vllm/models.go
+++ b/engine/internal/vllm/models.go
@@ -11,9 +11,9 @@ import (
 func ModelFilePath(modelDir, modelName string, format mv1.ModelFormat) (string, error) {
 	switch format {
 	case mv1.ModelFormat_MODEL_FORMAT_GGUF:
-		return filepath.Join(modelDir, modelName+".gguf"), nil
+		return filepath.Join(modelDir, modelName, "model.gguf"), nil
 	case mv1.ModelFormat_MODEL_FORMAT_HUGGING_FACE:
-		return modelDir, nil
+		return filepath.Join(modelDir, modelName), nil
 	default:
 		return "", fmt.Errorf("unsupported model format: %s", format)
 	}


### PR DESCRIPTION
To share the code with the Ollama runtime case.