### PR TITLE
Add a template for intfloat/e5-mistral-7b-instruct in vLLM

### DIFF
--- a/engine/internal/runtime/vllm_client.go
+++ b/engine/internal/runtime/vllm_client.go
@@ -184,7 +184,7 @@ func chatTemplate(modelName string) (string, error) {
 {{message['content']}}
 {% endfor %}
 `, nil
-	case strings.HasPrefix(modelName, "sentence-transformers-all-MiniLM-L6-v2"):
+	case modelName == "intfloat-e5-mistral-7b-instruct":
 		// This model is for embedding.
 		return `
 {% for message in messages %}


### PR DESCRIPTION
Remove the template for sentence-transformers-all-MiniLM-L6-v2 from vLLM as it doesn't work (no support of "bert" architecture).