### PR TITLE
Fix the runtime image config validation

### DIFF
--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -101,8 +101,8 @@ func (c *RuntimeConfig) validate() error {
 	if len(c.RuntimeImages) == 0 {
 		return fmt.Errorf("runtimeImages must be set")
 	}
-	if _, ok := c.RuntimeImages[c.Name]; !ok {
-		return fmt.Errorf("image not found for runtime %q", c.Name)
+	if len(c.RuntimeImages[c.Name]) == 0 {
+		return fmt.Errorf("runtimeImages must be set")
 	}
 	if err := validateImagePullPolicy(c.PullerImagePullPolicy); err != nil {
 		return fmt.Errorf("pullerImagePullPolicy: %s", err)


### PR DESCRIPTION
Handle a case where the runtime name is configured in the "model" instead of "runtime".